### PR TITLE
Fixed bug for the red button

### DIFF
--- a/OpenCR/src/hardware/dxl_hw_op3.h
+++ b/OpenCR/src/hardware/dxl_hw_op3.h
@@ -69,7 +69,7 @@ extern "C" {
     #define PIN_BUTTON_S1 HW_INTERFACE_BUTTON_RED
     #define PIN_BUTTON_S2 HW_INTERFACE_BUTTON_GREEN
     #define PIN_BUTTON_S3 HW_INTERFACE_BUTTON_BLACK
-    #define PIN_BUTTON_S4 59  // default value, unused
+    #define PIN_BUTTON_S4 56  // default value, unused
 
     #define DXL_POWER_DISABLE_BUTTON HW_INTERFACE_BUTTON_RED
 


### PR DESCRIPTION
### Brief
Correctly defines S4 as 56.
### Context
The definition for S4 in the firmware was incorrectly set as 59, equal to S1. Therefore, the intended pin for S4, pin-56, was in an unintended high-impedance/output state. Thus, when pin-56 and pin-59 were shorted by NUcr as specified, it pulled pin-59 down, triggering the power to be cut-off as if the red button was pushed.