### PR TITLE
Fix a few minor bugs to get KeyboardWalk to work reliably.

### DIFF
--- a/NUSense/Core/Src/dynamixel/PacketHandler.hpp
+++ b/NUSense/Core/Src/dynamixel/PacketHandler.hpp
@@ -120,7 +120,7 @@ namespace dynamixel {
          * @note    This must be called in order to handle timeouts.
          */
         void begin() {
-            // For now, wait for at most 500 microseconds.
+            // For now, wait for at most 1000 microseconds.
             timeout_timer.begin(1000);
         }
 

--- a/NUSense/Core/Src/imu.cpp
+++ b/NUSense/Core/Src/imu.cpp
@@ -136,6 +136,7 @@ void NUSense::IMU::readReg(Address addr, uint8_t* data) {
 void NUSense::IMU::readBurst(Address addr, uint8_t* data, uint16_t length) {
     uint8_t packet[length + 1];
     uint8_t rx_data[length + 1];
+    HAL_StatusTypeDef status;
 
     for (int i = 0; i < length + 1; i++) {
         rx_data[i] = 0xAA;
@@ -146,11 +147,13 @@ void NUSense::IMU::readBurst(Address addr, uint8_t* data, uint16_t length) {
     }
 
     HAL_GPIO_WritePin(MPU_NSS_GPIO_Port, MPU_NSS_Pin, GPIO_PIN_RESET);
-    HAL_SPI_TransmitReceive(&hspi4, packet, rx_data, length + 1, HAL_MAX_DELAY);
+    status = HAL_SPI_TransmitReceive(&hspi4, packet, rx_data, length + 1, 1);
     HAL_GPIO_WritePin(MPU_NSS_GPIO_Port, MPU_NSS_Pin, GPIO_PIN_SET);
 
-    for (int i = 0; i < length; i++)
-        data[i] = rx_data[i + 1];
+    if (status == HAL_OK) {
+        for (int i = 0; i < length; i++)
+            data[i] = rx_data[i + 1];
+    }
 }
 
 

--- a/NUSense/Core/Src/imu.cpp
+++ b/NUSense/Core/Src/imu.cpp
@@ -146,10 +146,13 @@ void NUSense::IMU::readBurst(Address addr, uint8_t* data, uint16_t length) {
             packet[i] = 0x00;
     }
 
+    // Wait for at most 1 ms for data to come back.
     HAL_GPIO_WritePin(MPU_NSS_GPIO_Port, MPU_NSS_Pin, GPIO_PIN_RESET);
     status = HAL_SPI_TransmitReceive(&hspi4, packet, rx_data, length + 1, 1);
     HAL_GPIO_WritePin(MPU_NSS_GPIO_Port, MPU_NSS_Pin, GPIO_PIN_SET);
 
+    // If there has been new data within that time, then update the data cache.
+    // Else, leave it.
     if (status == HAL_OK) {
         for (int i = 0; i < length; i++)
             data[i] = rx_data[i + 1];

--- a/NUSense/Core/Src/platform/NUSense/NUSenseIO/loop.cpp
+++ b/NUSense/Core/Src/platform/NUSense/NUSenseIO/loop.cpp
@@ -94,7 +94,7 @@ namespace platform::NUSense {
 
                     // Reset the flag now that the two write-instructions have begun.
                     servo_states[(uint8_t) current_id - 1].dirty = false;
-                    
+
                     send_servo_write_1_request(current_id, i);
                     status_states[(uint8_t) current_id - 1] = WRITE_1_RESPONSE;
                 }

--- a/NUSense/Core/Src/platform/NUSense/NUSenseIO/loop.cpp
+++ b/NUSense/Core/Src/platform/NUSense/NUSenseIO/loop.cpp
@@ -47,10 +47,6 @@ namespace platform::NUSense {
                     // for the read bank of registers.
                     case StatusState::WRITE_2_RESPONSE:
 
-                        // Reset the flag now that the two write-instructions were properly
-                        // received.
-                        servo_states[(uint8_t) current_id - 1].dirty = false;
-
                         send_servo_read_request(current_id, i);
                         status_states[(uint8_t) current_id - 1] = READ_RESPONSE;
 
@@ -70,6 +66,10 @@ namespace platform::NUSense {
 
                         // If the servo-state is dirty, then send a write-instruction.
                         if (servo_states[(uint8_t) current_id - 1].dirty) {
+
+                            // Reset the flag now that the two write-instructions have begun.
+                            servo_states[(uint8_t) current_id - 1].dirty = false;
+
                             send_servo_write_1_request(current_id, i);
                             status_states[(uint8_t) current_id - 1] = WRITE_1_RESPONSE;
                         }
@@ -91,6 +91,10 @@ namespace platform::NUSense {
 
                 // If the servo-state is dirty, then send a write-instruction.
                 if (servo_states[(uint8_t) current_id - 1].dirty) {
+
+                    // Reset the flag now that the two write-instructions have begun.
+                    servo_states[(uint8_t) current_id - 1].dirty = false;
+                    
                     send_servo_write_1_request(current_id, i);
                     status_states[(uint8_t) current_id - 1] = WRITE_1_RESPONSE;
                 }

--- a/NUSense/Core/Src/usb/PacketHandler.hpp
+++ b/NUSense/Core/Src/usb/PacketHandler.hpp
@@ -27,6 +27,7 @@ namespace usb {
         bool handle_incoming() {
 
             if (rx_buffer.size != 0) {
+                HAL_NVIC_DisableIRQ(OTG_HS_IRQn);
                 // Check if we have a header and if we do extract our lengths and pb bytes
                 if ((rx_buffer.data[rx_buffer.front] == (char) 0xE2)
                     && (rx_buffer.data[(rx_buffer.front + 1) % RX_BUF_SIZE] == (char) 0x98)
@@ -63,6 +64,7 @@ namespace usb {
                     rx_buffer.front = (rx_buffer.front + 1) % RX_BUF_SIZE;
                     rx_buffer.size--;
                 }
+                HAL_NVIC_EnableIRQ(OTG_HS_IRQn);
             }
 
             if (is_packet_ready) {

--- a/NUSense/Core/Src/utility/support/MicrosecondTimer.hpp
+++ b/NUSense/Core/Src/utility/support/MicrosecondTimer.hpp
@@ -56,6 +56,15 @@ namespace utility::support {
         }
 
         /**
+         * @brief   Restarts the timer.
+         * @param   timeout the timeout in microseconds, at most 65535.
+         */
+        void restart(uint16_t timeout) {
+            stop();
+            begin(timeout);
+        }
+
+        /**
          * @brief   Sees whether the timer has timed out.
          * @note    This should be kept very short.
          * @return  whether the timer has timed out,
@@ -68,7 +77,7 @@ namespace utility::support {
                 // saw-tooth wave.
                 if (!((count - threshold) & 0x8000)) {
                     // Since the timer has timed out, it is no longer counting.
-                    is_counting = false;
+                    stop();
                     return true;
                 }
                 else

--- a/NUSense/USB_DEVICE/App/usbd_cdc_if.c
+++ b/NUSense/USB_DEVICE/App/usbd_cdc_if.c
@@ -277,7 +277,7 @@ static int8_t CDC_Receive_HS(uint8_t* Buf, uint32_t *Len)
             rx_buffer.data[i] = Buf[RX_BUF_SIZE - rx_buffer.back + i];
           }
       }
-      // If not then, one copy should be enough.
+      // If not, then one copy should be enough.
       else {
           // Use a dumb for-loop since memcpy throws the volatile qualifier away which apparently 
           // can lead to undefined behaviour.


### PR DESCRIPTION
This branch is mainly to collect a few small fixes for a few small bugs on the NUSense firmware. After this, KeyboardWalk should be mostly reliable.

Such bugs were:
- NUSense hitting a hard fault (like a segmentation fault), possibly because of a race-condition with the CDC callback,
- a servo missing frames because its dirty servo-state was ignored since the dirty-flag was reset after some delay,
- and the firmware getting stuck on a blocking function with an indefinite timeout for the IMU.

Such fixes are:
- to disable the OTG_HS IRQ when the ring-buffer for the USB-communications is being handled lest there may be a race-condition*,
- to reset the dirty-flag of the servo-state straight away before a write-instruction is sent lest a ServoTarget is ignored as the flag is reset afterwards,
- to change the packet timeout-timer to time single bytes rather than a whole packet being decoded lest the Dynamixel loop is throttled too much†,
- to make the IMU's polling timeout lest the firmware gets bricked at that one spot‡,
- and to change the `memcpy`'s in the CDC callback to be for-loops since the former throws away the volatile qualifier.

\* This is rough fix since the fault itself was [an imprecise or asynchronous bus-fault](https://www.keil.com/appnotes/files/apnt209.pdf). [Disabling an internal buffer](https://www.beningo.com/how-to-debug-a-hard-fault-on-an-arm-cortex-m/) apparently makes it easier to troubleshoot. However, disabling the IRQ seems to work well. No hard-fault comes up when the robot is standing for about half an hour. Furthermore, too much time should not be spent since StreamReactor may have a better approach. Interestingly, this bug only happened with the firmware was fully optimised.
† I am not sure about this since it does allow a more accurate timing of missing bytes, but it may never time out if there is a consistent enough stream of garbage. However, Dex's independent watchdog idea may help this.
‡ We may want to make a more thorough DMA approach; see [this task](https://nubots.atlassian.net/browse/HW-68?atlOrigin=eyJpIjoiNDEyNGFhNTg5MjYyNDE5NDk3NWRiMjM1MTY3ZWI2MGYiLCJwIjoiaiJ9).