### PR TITLE
Fix broken OpenCR buzzer

### DIFF
--- a/OpenCR/src/debug/dxl_debug.cpp
+++ b/OpenCR/src/debug/dxl_debug.cpp
@@ -37,6 +37,7 @@ static bool dxl_debug_menu_loop(uint8_t ch);
 static void dxl_debug_menu_show_cmdline(void);
 static bool dxl_debug_menu_show_ctrltbl();
 
+static void dxl_debug_write_ctrltbl(void);
 static void dxl_debug_send_write_command(void);
 static void dxl_debug_test_gpio(void);
 static void dxl_debug_buzzer();
@@ -134,6 +135,11 @@ bool dxl_debug_menu_loop(uint8_t ch) {
         case 'l':
             DEBUG_SERIAL.println(" ");
             dxl_debug_menu_show_ctrltbl();
+            break;
+
+        case 'c':
+            DEBUG_SERIAL.println(" ");
+            dxl_debug_write_ctrltbl();
             break;
 
         case 's':
@@ -345,6 +351,104 @@ bool dxl_debug_menu_show_ctrltbl() {
     DEBUG_SERIAL.print(p_dxl_mem->IMU_Control);
     DEBUG_SERIAL.print("\t 0x");
     DEBUG_SERIAL.println(p_dxl_mem->IMU_Control, HEX);
+}
+
+/**
+ * @brief Write a value to the control table at a given address
+ */
+void dxl_debug_write_ctrltbl(void) {
+    DEBUG_SERIAL.print("[>] Address: ");
+    while (!DEBUG_SERIAL.available())
+        ;
+    int addr = DEBUG_SERIAL.parseInt();
+
+    // Match address to control table
+    uint8_t known;
+    switch (addr) {
+        case 0:
+        case 2:
+        case 3:
+        case 4:
+        case 5:
+        case 16:
+        case 18:
+        case 20:
+        case 22:
+        case 24:
+        case 25:
+        case 26:
+        case 28:
+        case 30:
+        case 31:
+        case 32:
+        case 34:
+        case 36:
+        case 38:
+        case 40:
+        case 42:
+        case 44:
+        case 46:
+        case 48:
+        case 50: known = 1; break;
+        default: known = 0; break;
+    }
+
+    // Confirm if the address isn't a known address
+    if (!known) {
+        DEBUG_SERIAL.print("[!] Address ");
+        DEBUG_SERIAL.print(addr);
+        DEBUG_SERIAL.println(" is not a known control table field. Proceed? (y/N)");
+        while (!DEBUG_SERIAL.available())
+            ;
+        char c = DEBUG_SERIAL.read();
+        if (c != 'y')
+            return;
+    }
+
+    DEBUG_SERIAL.print("[>] Value: ");
+    while (!DEBUG_SERIAL.available())
+        ;
+    int val = DEBUG_SERIAL.parseInt();
+
+    // Print confirmation with name of address if possible
+    DEBUG_SERIAL.print("[*] Writing value ");
+    // Print in hex for easy reading and simple validation
+    // DEBUG_SERIAL.print("0x");
+    // DEBUG_SERIAL.print(val, HEX);
+    DEBUG_SERIAL.print(val);
+    DEBUG_SERIAL.print(" to ");
+    switch (addr) {
+        case 0: DEBUG_SERIAL.print("Model_Number"); break;
+        case 2: DEBUG_SERIAL.print("Firmware_Version"); break;
+        case 3: DEBUG_SERIAL.print("ID"); break;
+        case 4: DEBUG_SERIAL.print("Baud"); break;
+        case 5: DEBUG_SERIAL.print("Return_Delay_Time"); break;
+        case 16: DEBUG_SERIAL.print("Status_Return_Level"); break;
+        case 18: DEBUG_SERIAL.print("Roll_Offset"); break;
+        case 20: DEBUG_SERIAL.print("Pitch_Offset"); break;
+        case 22: DEBUG_SERIAL.print("Yaw_Offset"); break;
+        case 24: DEBUG_SERIAL.print("Dynamixel_Power"); break;
+        case 25: DEBUG_SERIAL.print("LED"); break;
+        case 26: DEBUG_SERIAL.print("LED_RGB"); break;
+        case 28: DEBUG_SERIAL.print("Buzzer"); break;
+        case 30: DEBUG_SERIAL.print("Button"); break;
+        case 31: DEBUG_SERIAL.print("Voltage"); break;
+        case 32: DEBUG_SERIAL.print("Gyro_X"); break;
+        case 34: DEBUG_SERIAL.print("Gyro_Y"); break;
+        case 36: DEBUG_SERIAL.print("Gyro_Z"); break;
+        case 38: DEBUG_SERIAL.print("Acc_X"); break;
+        case 40: DEBUG_SERIAL.print("Acc_Y"); break;
+        case 42: DEBUG_SERIAL.print("Acc_Z"); break;
+        case 44: DEBUG_SERIAL.print("Roll"); break;
+        case 46: DEBUG_SERIAL.print("Pitch"); break;
+        case 48: DEBUG_SERIAL.print("Yaw"); break;
+        case 50: DEBUG_SERIAL.print("IMU_Control"); break;
+        default: DEBUG_SERIAL.print("Unknown"); break;
+    }
+    DEBUG_SERIAL.println(".");
+
+    // get the address of the value in the control table
+    dxl_debug_write_byte_wrapper(addr, val);
 }
 
 /**

--- a/OpenCR/src/debug/dxl_debug.cpp
+++ b/OpenCR/src/debug/dxl_debug.cpp
@@ -35,7 +35,7 @@ const char override_char = '`';  // grave (`)
 static void dxl_debug_menu_show_list(void);
 static bool dxl_debug_menu_loop(uint8_t ch);
 static void dxl_debug_menu_show_cmdline(void);
-static bool dxl_debug_menu_shwo_ctrltbl();
+static bool dxl_debug_menu_show_ctrltbl();
 
 static void dxl_debug_send_write_command(void);
 static void dxl_debug_test_gpio(void);
@@ -91,6 +91,7 @@ void dxl_debug_menu_show_list(void) {
     DEBUG_SERIAL.println("m - show menu");
     DEBUG_SERIAL.println("d - show step");
     DEBUG_SERIAL.println("l - show control table");
+    DEBUG_SERIAL.println("c - write to control table");
     DEBUG_SERIAL.println("s - send dynamixel write command");
     DEBUG_SERIAL.println("g - test gpio (buttons)");
     DEBUG_SERIAL.println("b - test buzzer");
@@ -132,7 +133,7 @@ bool dxl_debug_menu_loop(uint8_t ch) {
 
         case 'l':
             DEBUG_SERIAL.println(" ");
-            dxl_debug_menu_shwo_ctrltbl();
+            dxl_debug_menu_show_ctrltbl();
             break;
 
         case 's':
@@ -163,10 +164,10 @@ bool dxl_debug_menu_loop(uint8_t ch) {
 
 
 /*---------------------------------------------------------------------------
-     TITLE   : dxl_debug_menu_shwo_ctrltbl
+     TITLE   : dxl_debug_menu_show_ctrltbl
      WORK    :
 ---------------------------------------------------------------------------*/
-bool dxl_debug_menu_shwo_ctrltbl() {
+bool dxl_debug_menu_show_ctrltbl() {
     uint32_t addr;
 
 

--- a/OpenCR/src/debug/dxl_debug.cpp
+++ b/OpenCR/src/debug/dxl_debug.cpp
@@ -40,7 +40,6 @@ static bool dxl_debug_menu_shwo_ctrltbl();
 static void dxl_debug_send_write_command(void);
 static void dxl_debug_test_gpio(void);
 static void dxl_debug_buzzer();
-static void dxl_debug_buzzer_no_end();
 
 
 /*---------------------------------------------------------------------------
@@ -94,7 +93,7 @@ void dxl_debug_menu_show_list(void) {
     DEBUG_SERIAL.println("l - show control table");
     DEBUG_SERIAL.println("s - send dynamixel write command");
     DEBUG_SERIAL.println("g - test gpio (buttons)");
-    DEBUG_SERIAL.println("b - test buzzer (or v for alt)");
+    DEBUG_SERIAL.println("b - test buzzer");
     DEBUG_SERIAL.println("q - exit menu");
     DEBUG_SERIAL.println("---------------------------");
 }
@@ -149,11 +148,6 @@ bool dxl_debug_menu_loop(uint8_t ch) {
         case 'b':
             DEBUG_SERIAL.println(" ");
             dxl_debug_buzzer();
-            break;
-
-        case 'v':
-            DEBUG_SERIAL.println(" ");
-            dxl_debug_buzzer_no_end();
             break;
 
         default: exit_menu = true; break;
@@ -613,7 +607,7 @@ void dxl_debug_buzzer() {
         ;
     int dur = DEBUG_SERIAL.parseInt();
 
-    // End if frequency is 0
+    // End if frequency is 0, delayed by duration
     if (freq == 0) {
         delay(dur);
         noTone(BDPIN_BUZZER);
@@ -629,52 +623,6 @@ void dxl_debug_buzzer() {
     if (dur == 0) {
         DEBUG_SERIAL.println(" indefinitely.");
         tone(BDPIN_BUZZER, freq);
-        return;
-    }
-
-    // Confirm duration
-    DEBUG_SERIAL.print(" for ");
-    DEBUG_SERIAL.print(dur);
-    DEBUG_SERIAL.println("ms");
-
-    // Play the tone normally
-    tone(BDPIN_BUZZER, freq, dur);
-    delay(dur);
-    noTone(BDPIN_BUZZER);
-}
-
-/**
- * @brief Sound the buzzer at a given frequency and duration but WITHOUT the final delay and noTime
- */
-void dxl_debug_buzzer_no_end() {
-    DEBUG_SERIAL.print("[>] Frequency (Hz): ");
-    while (!DEBUG_SERIAL.available())
-        ;
-    int freq = DEBUG_SERIAL.parseInt();
-
-    DEBUG_SERIAL.print("[>] Duration (ms): ");
-    while (!DEBUG_SERIAL.available())
-        ;
-    int dur = DEBUG_SERIAL.parseInt();
-
-    // End if frequency is 0
-    if (freq == 0) {
-        delay(dur);
-        noTone(BDPIN_BUZZER);
-        return;
-    }
-
-    // Confirm frequency
-    DEBUG_SERIAL.print("[*] Playing tone at ");
-    DEBUG_SERIAL.print(freq);
-    DEBUG_SERIAL.print("Hz");
-
-    // Test without duration if duration is 0
-    if (dur == 0) {
-        DEBUG_SERIAL.println(" indefinitely.");
-        tone(BDPIN_BUZZER, freq);
-        // testing: what happens if we add a blocking delay here?
-        delay(100);
 
         return;
     }

--- a/OpenCR/src/debug/dxl_debug.cpp
+++ b/OpenCR/src/debug/dxl_debug.cpp
@@ -39,6 +39,8 @@ static bool dxl_debug_menu_shwo_ctrltbl();
 
 static void dxl_debug_send_write_command(void);
 static void dxl_debug_test_gpio(void);
+static void dxl_debug_buzzer();
+static void dxl_debug_buzzer_no_end();
 
 
 /*---------------------------------------------------------------------------
@@ -92,6 +94,7 @@ void dxl_debug_menu_show_list(void) {
     DEBUG_SERIAL.println("l - show control table");
     DEBUG_SERIAL.println("s - send dynamixel write command");
     DEBUG_SERIAL.println("g - test gpio (buttons)");
+    DEBUG_SERIAL.println("b - test buzzer (or v for alt)");
     DEBUG_SERIAL.println("q - exit menu");
     DEBUG_SERIAL.println("---------------------------");
 }
@@ -143,6 +146,15 @@ bool dxl_debug_menu_loop(uint8_t ch) {
             dxl_debug_test_gpio();
             break;
 
+        case 'b':
+            DEBUG_SERIAL.println(" ");
+            dxl_debug_buzzer();
+            break;
+
+        case 'v':
+            DEBUG_SERIAL.println(" ");
+            dxl_debug_buzzer_no_end();
+            break;
 
         default: exit_menu = true; break;
     }
@@ -586,4 +598,92 @@ void dxl_debug_test_gpio(void) {
     while (ch != 'm');
     // show menu
     dxl_debug_menu_show_list();
+}
+/**
+ * @brief Sound the buzzer at a given frequency and duration
+ */
+void dxl_debug_buzzer() {
+    DEBUG_SERIAL.print("[>] Frequency (Hz): ");
+    while (!DEBUG_SERIAL.available())
+        ;
+    int freq = DEBUG_SERIAL.parseInt();
+
+    DEBUG_SERIAL.print("[>] Duration (ms): ");
+    while (!DEBUG_SERIAL.available())
+        ;
+    int dur = DEBUG_SERIAL.parseInt();
+
+    // End if frequency is 0
+    if (freq == 0) {
+        delay(dur);
+        noTone(BDPIN_BUZZER);
+        return;
+    }
+
+    // Confirm frequency
+    DEBUG_SERIAL.print("[*] Playing tone at ");
+    DEBUG_SERIAL.print(freq);
+    DEBUG_SERIAL.print("Hz");
+
+    // Test without duration if duration is 0
+    if (dur == 0) {
+        DEBUG_SERIAL.println(" indefinitely.");
+        tone(BDPIN_BUZZER, freq);
+        return;
+    }
+
+    // Confirm duration
+    DEBUG_SERIAL.print(" for ");
+    DEBUG_SERIAL.print(dur);
+    DEBUG_SERIAL.println("ms");
+
+    // Play the tone normally
+    tone(BDPIN_BUZZER, freq, dur);
+    delay(dur);
+    noTone(BDPIN_BUZZER);
+}
+
+/**
+ * @brief Sound the buzzer at a given frequency and duration but WITHOUT the final delay and noTime
+ */
+void dxl_debug_buzzer_no_end() {
+    DEBUG_SERIAL.print("[>] Frequency (Hz): ");
+    while (!DEBUG_SERIAL.available())
+        ;
+    int freq = DEBUG_SERIAL.parseInt();
+
+    DEBUG_SERIAL.print("[>] Duration (ms): ");
+    while (!DEBUG_SERIAL.available())
+        ;
+    int dur = DEBUG_SERIAL.parseInt();
+
+    // End if frequency is 0
+    if (freq == 0) {
+        delay(dur);
+        noTone(BDPIN_BUZZER);
+        return;
+    }
+
+    // Confirm frequency
+    DEBUG_SERIAL.print("[*] Playing tone at ");
+    DEBUG_SERIAL.print(freq);
+    DEBUG_SERIAL.print("Hz");
+
+    // Test without duration if duration is 0
+    if (dur == 0) {
+        DEBUG_SERIAL.println(" indefinitely.");
+        tone(BDPIN_BUZZER, freq);
+        // testing: what happens if we add a blocking delay here?
+        delay(100);
+
+        return;
+    }
+
+    // Confirm duration
+    DEBUG_SERIAL.print(" for ");
+    DEBUG_SERIAL.print(dur);
+    DEBUG_SERIAL.println("ms");
+
+    // Play the tone normally
+    tone(BDPIN_BUZZER, freq, dur);
 }

--- a/OpenCR/src/debug/dxl_debug.cpp
+++ b/OpenCR/src/debug/dxl_debug.cpp
@@ -617,6 +617,7 @@ void dxl_debug_buzzer() {
     if (freq == 0) {
         delay(dur);
         noTone(BDPIN_BUZZER);
+        digitalWriteFast(HW_ALT_BUZZER_PIN, LOW);
         return;
     }
 
@@ -629,6 +630,7 @@ void dxl_debug_buzzer() {
     if (dur == 0) {
         DEBUG_SERIAL.println(" indefinitely.");
         tone(BDPIN_BUZZER, freq);
+        digitalWriteFast(HW_ALT_BUZZER_PIN, HIGH);
         return;
     }
 

--- a/OpenCR/src/debug/dxl_debug.cpp
+++ b/OpenCR/src/debug/dxl_debug.cpp
@@ -617,7 +617,6 @@ void dxl_debug_buzzer() {
     if (freq == 0) {
         delay(dur);
         noTone(BDPIN_BUZZER);
-        digitalWriteFast(HW_ALT_BUZZER_PIN, LOW);
         return;
     }
 
@@ -630,7 +629,6 @@ void dxl_debug_buzzer() {
     if (dur == 0) {
         DEBUG_SERIAL.println(" indefinitely.");
         tone(BDPIN_BUZZER, freq);
-        digitalWriteFast(HW_ALT_BUZZER_PIN, HIGH);
         return;
     }
 

--- a/OpenCR/src/hardware/dxl_hw_interface.h
+++ b/OpenCR/src/hardware/dxl_hw_interface.h
@@ -43,14 +43,14 @@
  *          > sets global for PWM value
  *      - handler_led(void)
  *          > Triggered by interrupt, sets values based on globals
- *
+ * 
  * - The interface board has:
  *     S1 -> Silkscreen GPIO 9  (TEST_PIN7)
  *     S2 -> Silkscreen GPIO 10 (TEST_PIN8)
  *     S3 -> Silkscreen GPIO 11 (TEST_PIN9)
  *     Short Silkscreen GPIO 9 and 12 (TEST_PIN7 and TEST_PIN_10)
- *      - This shorts S1 and S4, because S1 is our red button but the
- *        default firmware uses S4 for Dynamixel power disable. Avoids
+ *      - This shorts S1 and S4, because S1 is our red button but the 
+ *        default firmware uses S4 for Dynamixel power disable. Avoids 
  *        potential problems in the future.
  */
 
@@ -70,9 +70,6 @@
 #define HW_INTERFACE_LED_R BDPIN_GPIO_1  // 50
 #define HW_INTERFACE_LED_G BDPIN_GPIO_2  // 51
 #define HW_INTERFACE_LED_B BDPIN_GPIO_3  // 52
-
-// Add a second buzzer on a GPIO pin because the OpenCR buzzer won't play nice
-#define HW_ALT_BUZZER_PIN BDPIN_GPIO_18
 
 #endif  // DXL_HW_INTERFACE_H
 

--- a/OpenCR/src/hardware/dxl_hw_interface.h
+++ b/OpenCR/src/hardware/dxl_hw_interface.h
@@ -43,14 +43,14 @@
  *          > sets global for PWM value
  *      - handler_led(void)
  *          > Triggered by interrupt, sets values based on globals
- * 
+ *
  * - The interface board has:
  *     S1 -> Silkscreen GPIO 9  (TEST_PIN7)
  *     S2 -> Silkscreen GPIO 10 (TEST_PIN8)
  *     S3 -> Silkscreen GPIO 11 (TEST_PIN9)
  *     Short Silkscreen GPIO 9 and 12 (TEST_PIN7 and TEST_PIN_10)
- *      - This shorts S1 and S4, because S1 is our red button but the 
- *        default firmware uses S4 for Dynamixel power disable. Avoids 
+ *      - This shorts S1 and S4, because S1 is our red button but the
+ *        default firmware uses S4 for Dynamixel power disable. Avoids
  *        potential problems in the future.
  */
 
@@ -70,6 +70,9 @@
 #define HW_INTERFACE_LED_R BDPIN_GPIO_1  // 50
 #define HW_INTERFACE_LED_G BDPIN_GPIO_2  // 51
 #define HW_INTERFACE_LED_B BDPIN_GPIO_3  // 52
+
+// Add a second buzzer on a GPIO pin because the OpenCR buzzer won't play nice
+#define HW_ALT_BUZZER_PIN BDPIN_GPIO_18
 
 #endif  // DXL_HW_INTERFACE_H
 

--- a/OpenCR/src/hardware/dxl_hw_op3.cpp
+++ b/OpenCR/src/hardware/dxl_hw_op3.cpp
@@ -106,7 +106,6 @@ void dxl_hw_op3_init(void) {
     pinMode(PIN_BUTTON_S3, INPUT_PULLUP);
     pinMode(PIN_BUTTON_S4, INPUT_PULLUP);
 
-    pinMode(HW_ALT_BUZZER_PIN, OUTPUT);
 
     dxl_hw_op3_led_set(PIN_LED_1, 1);  // R
     dxl_hw_op3_led_set(PIN_LED_2, 1);  // G

--- a/OpenCR/src/hardware/dxl_hw_op3.cpp
+++ b/OpenCR/src/hardware/dxl_hw_op3.cpp
@@ -31,11 +31,11 @@ static uint8_t button_value[BUTTON_PIN_MAX];
 static uint32_t button_pin_num[BUTTON_PIN_MAX] = {PIN_BUTTON_S1, PIN_BUTTON_S2, PIN_BUTTON_S3, PIN_BUTTON_S4};
 
 
-#define BATTERY_POWER_OFF      0
-#define BATTERY_POWER_STARTUP  1
-#define BATTERY_POWER_NORMAL   2
-#define BATTERY_POWER_CHECK    3
-#define BATTERY_POWER_WARNNING 4
+#define BATTERY_POWER_OFF     0
+#define BATTERY_POWER_STARTUP 1
+#define BATTERY_POWER_NORMAL  2
+#define BATTERY_POWER_CHECK   3
+#define BATTERY_POWER_WARNING 4
 
 
 static uint8_t battery_voltage   = 0;
@@ -339,7 +339,7 @@ void dxl_hw_op3_voltage_update(void) {
                 else {
                     if (battery_voltage_raw < voltage_ref) {
                         prev_state    = battery_state;
-                        battery_state = BATTERY_POWER_WARNNING;
+                        battery_state = BATTERY_POWER_WARNING;
                     }
                 }
                 if (battery_voltage_raw >= voltage_ref) {
@@ -348,9 +348,9 @@ void dxl_hw_op3_voltage_update(void) {
                 }
                 break;
 
-            case BATTERY_POWER_WARNNING:
-                // alram_state ^= 1;
-                // if(alram_state)
+            case BATTERY_POWER_WARNING:
+                // alarm_state ^= 1;
+                // if(alarm_state)
                 //{
                 //   tone(BDPIN_BUZZER, 1000, 500);
                 // }
@@ -369,7 +369,7 @@ void dxl_hw_op3_voltage_update(void) {
         }
     }
 
-    if (battery_state == BATTERY_POWER_WARNNING) {
+    if (battery_state == BATTERY_POWER_WARNING) {
         if (millis() - process_time[2] >= 200) {
             process_time[2] = millis();
 

--- a/OpenCR/src/hardware/dxl_hw_op3.cpp
+++ b/OpenCR/src/hardware/dxl_hw_op3.cpp
@@ -311,9 +311,6 @@ void dxl_hw_op3_voltage_update(void) {
                     prev_state    = battery_state;
                     battery_state = BATTERY_POWER_STARTUP;
                 }
-                else {
-                    noTone(BDPIN_BUZZER);
-                }
                 break;
 
             case BATTERY_POWER_STARTUP:

--- a/OpenCR/src/hardware/dxl_hw_op3.cpp
+++ b/OpenCR/src/hardware/dxl_hw_op3.cpp
@@ -39,7 +39,7 @@ static uint32_t button_pin_num[BUTTON_PIN_MAX] = {PIN_BUTTON_S1, PIN_BUTTON_S2, 
 
 
 static uint8_t battery_voltage   = 0;
-static float battery_valtage_raw = 0;
+static float battery_voltage_raw = 0;
 static uint8_t battery_state     = BATTERY_POWER_STARTUP;
 
 
@@ -254,7 +254,7 @@ void dxl_hw_op3_voltage_update(void) {
     static bool startup    = false;
     static int adc_index   = 0;
     static int prev_state  = 0;
-    static int alram_state = 0;
+    static int alarm_state = 0;
     static int check_index = 0;
 
     int i;
@@ -287,13 +287,13 @@ void dxl_hw_op3_voltage_update(void) {
         }
         adc_value           = adc_sum / 10;
         vol_value           = map(adc_value, 0, 1023, 0, 331 * 57 / 10);
-        battery_valtage_raw = vol_value / 100;
+        battery_voltage_raw = vol_value / 100;
 
-        battery_valtage_raw += 0.5;
+        battery_voltage_raw += 0.5;
 
         // /// Serial.println(vol_value);
 
-        vol_value       = battery_valtage_raw * 10;
+        vol_value       = battery_voltage_raw * 10;
         vol_value       = constrain(vol_value, 0, 255);
         battery_voltage = vol_value;
     }
@@ -305,15 +305,15 @@ void dxl_hw_op3_voltage_update(void) {
 
         switch (battery_state) {
             case BATTERY_POWER_OFF:
-                alram_state = 0;
-                if (battery_valtage_raw > voltage_ref * 0.20) {
+                alarm_state = 0;
+                if (battery_voltage_raw > voltage_ref * 0.20) {
                     prev_state    = battery_state;
                     battery_state = BATTERY_POWER_STARTUP;
                 }
                 break;
 
             case BATTERY_POWER_STARTUP:
-                if (battery_valtage_raw > voltage_ref) {
+                if (battery_voltage_raw > voltage_ref) {
                     prev_state    = battery_state;
                     battery_state = BATTERY_POWER_NORMAL;
                 }
@@ -324,8 +324,8 @@ void dxl_hw_op3_voltage_update(void) {
                 break;
 
             case BATTERY_POWER_NORMAL:
-                alram_state = 0;
-                if (battery_valtage_raw < voltage_ref) {
+                alarm_state = 0;
+                if (battery_voltage_raw < voltage_ref) {
                     prev_state    = battery_state;
                     battery_state = BATTERY_POWER_CHECK;
                     check_index   = 0;
@@ -337,12 +337,12 @@ void dxl_hw_op3_voltage_update(void) {
                     check_index++;
                 }
                 else {
-                    if (battery_valtage_raw < voltage_ref) {
+                    if (battery_voltage_raw < voltage_ref) {
                         prev_state    = battery_state;
                         battery_state = BATTERY_POWER_WARNNING;
                     }
                 }
-                if (battery_valtage_raw >= voltage_ref) {
+                if (battery_voltage_raw >= voltage_ref) {
                     prev_state    = battery_state;
                     battery_state = BATTERY_POWER_NORMAL;
                 }
@@ -355,11 +355,11 @@ void dxl_hw_op3_voltage_update(void) {
                 //   tone(BDPIN_BUZZER, 1000, 500);
                 // }
 
-                if (battery_valtage_raw > voltage_ref) {
+                if (battery_voltage_raw > voltage_ref) {
                     prev_state    = battery_state;
                     battery_state = BATTERY_POWER_NORMAL;
                 }
-                if (battery_valtage_raw < voltage_ref * 0.20) {
+                if (battery_voltage_raw < voltage_ref * 0.20) {
                     prev_state    = battery_state;
                     battery_state = BATTERY_POWER_OFF;
                 }

--- a/OpenCR/src/hardware/dxl_hw_op3.cpp
+++ b/OpenCR/src/hardware/dxl_hw_op3.cpp
@@ -106,6 +106,7 @@ void dxl_hw_op3_init(void) {
     pinMode(PIN_BUTTON_S3, INPUT_PULLUP);
     pinMode(PIN_BUTTON_S4, INPUT_PULLUP);
 
+    pinMode(HW_ALT_BUZZER_PIN, OUTPUT);
 
     dxl_hw_op3_led_set(PIN_LED_1, 1);  // R
     dxl_hw_op3_led_set(PIN_LED_2, 1);  // G

--- a/OpenCR/src/hardware/dxl_hw_op3.cpp
+++ b/OpenCR/src/hardware/dxl_hw_op3.cpp
@@ -291,7 +291,6 @@ void dxl_hw_op3_voltage_update(void) {
 
         battery_voltage_raw += 0.5;
 
-        // /// Serial.println(vol_value);
 
         vol_value       = battery_voltage_raw * 10;
         vol_value       = constrain(vol_value, 0, 255);

--- a/OpenCR/src/hardware/dxl_hw_op3.cpp
+++ b/OpenCR/src/hardware/dxl_hw_op3.cpp
@@ -348,11 +348,6 @@ void dxl_hw_op3_voltage_update(void) {
                 break;
 
             case BATTERY_POWER_WARNING:
-                // alarm_state ^= 1;
-                // if(alarm_state)
-                //{
-                //   tone(BDPIN_BUZZER, 1000, 500);
-                // }
 
                 if (battery_voltage_raw > voltage_ref) {
                     prev_state    = battery_state;

--- a/OpenCR/src/protocol/dxl.cpp
+++ b/OpenCR/src/protocol/dxl.cpp
@@ -129,8 +129,7 @@ void dxlAddInstFunc(dxl_t* p_packet, uint8_t inst, dxl_error_t (*func)(dxl_t* p_
 dxl_error_t dxlProcessInst(dxl_t* p_packet) {
     dxl_error_t ret = DXL_RET_OK;
     uint8_t inst;
-    dxl_error_t (*func)(dxl_t * p_dxl);
-
+    dxl_error_t (*func)(dxl_t* p_dxl);
 
     inst = p_packet->rx.cmd;
     func = NULL;
@@ -168,9 +167,15 @@ dxl_error_t dxlProcessInst(dxl_t* p_packet) {
         return DXL_RET_EMPTY;
     }
 
-    // check the packet ID belongs to the OpenCR or is broadcast/global IS
+    // check the packet ID belongs to the OpenCR or is broadcast/global ID
     if (p_packet->rx.id != dxlGetId(p_packet) && p_packet->rx.id != DXL_GLOBAL_ID) {
         return DXL_RET_ERROR_NO_ID;
+    }
+
+    // Ignore broadcast sync read/write instructions because we assume they are
+    // meant for servos in the chain. This stops the logs from clogging up.
+    if (p_packet->rx.id == DXL_GLOBAL_ID && (inst == INST_SYNC_READ || inst == INST_SYNC_WRITE)) {
+        return DXL_RET_EMPTY;
     }
 
     // checks passed, call function

--- a/OpenCR/src/protocol/dxl.cpp
+++ b/OpenCR/src/protocol/dxl.cpp
@@ -8,6 +8,7 @@
 
 #include <stdlib.h>
 
+#include "../debug/dxl_debug.h"
 #include "../dxl_def.h"
 #include "../hardware/dxl_hw.h"
 
@@ -162,6 +163,8 @@ dxl_error_t dxlProcessInst(dxl_t* p_packet) {
 
     // check the function was recognised/exists
     if (func == NULL) {
+        if (debug_state)
+            Serial.println("[!] dxlProcessInst: No function found for instruction");
         return DXL_RET_EMPTY;
     }
 

--- a/OpenCR/src/protocol/dxl_node_op3.cpp
+++ b/OpenCR/src/protocol/dxl_node_op3.cpp
@@ -461,13 +461,19 @@ void dxl_node_write_byte(uint16_t addr, uint8_t data) {
     }
 
     if (RANGE_CHECK(addr, p_dxl_mem->Buzzer)) {
+        /* debug */
+        Serial.print("[#] Setting buzzer value from control table");
+
         if (p_dxl_mem->Buzzer > 0)
             tone(BDPIN_BUZZER, p_dxl_mem->Buzzer);
         else
             noTone(BDPIN_BUZZER);
     }
 }
-
+// This is a wrapper so that we can call this function from the debug module
+void dxl_debug_write_byte_wrapper(uint16_t addr, uint8_t data) {
+    dxl_node_write_byte(addr, data);
+}
 
 /*---------------------------------------------------------------------------
      TITLE   : dxl_node_check_range
@@ -475,13 +481,37 @@ void dxl_node_write_byte(uint16_t addr, uint8_t data) {
 ---------------------------------------------------------------------------*/
 BOOL dxl_node_check_range(uint16_t addr, uint32_t addr_ptr, uint8_t length) {
 
+    // Calculate the offset of the address in the control table
     uint32_t addr_offset = addr_ptr - (uint32_t) p_dxl_mem;
 
+    /* debug */
+    if (debug_state) {
+        Serial.print("[#] Checking range: ");
+        Serial.print(addr);
+        Serial.print(" @ 0x");
+        Serial.print(addr_ptr, HEX);
+        Serial.print(" (offset ");
+        Serial.print(addr_offset);
+        if (addr_offset < 10)
+            Serial.print(")  len ");
+        else
+            Serial.print(") len ");
+        Serial.println(length);
+    }
+
+    // Equivalent to:
+    //   length - <= (addr - addr_offset) < length
+    // i.e. addr is within the range of the control table value
     if (addr >= (addr_offset + length - 1) && addr < (addr_offset + length)) {
+        /* debug */
+        if (debug_state)
+            Serial.println(" -> [#] PASS");
         return TRUE;
     }
 
-
+    /* debug */
+    if (debug_state)
+        Serial.println(" -> [#] FAIL");
     return FALSE;
 }
 

--- a/OpenCR/src/protocol/dxl_node_op3.cpp
+++ b/OpenCR/src/protocol/dxl_node_op3.cpp
@@ -462,7 +462,7 @@ void dxl_node_write_byte(uint16_t addr, uint8_t data) {
 
     if (RANGE_CHECK(addr, data, p_dxl_mem->Buzzer)) {
         /* debug */
-        Serial.println("[#] Setting buzzer value from control table change");
+        // Serial.printf("[#] Setting buzzer (%d) to %d\n", addr, data);
 
         if (p_dxl_mem->Buzzer > 0)
             tone(BDPIN_BUZZER, p_dxl_mem->Buzzer);
@@ -504,7 +504,7 @@ void processRead(uint16_t addr, uint8_t* p_data, uint16_t length) {
 }
 
 void processWrite(uint16_t addr, uint8_t* p_data, uint16_t length) {
-    /// Serial.printf("Writing to memory address 0x%02x (%d): ", addr, addr);
+    // Serial.printf("[#] Writing %d bytes to memory address 0x%02x (%d):\n ->", length, addr, addr);
 
     for (uint32_t i = 0; i < length; i++) {
         if (mem.attr[addr] & DXL_MEM_ATTR_WO || mem.attr[addr] & DXL_MEM_ATTR_RW) {
@@ -512,11 +512,11 @@ void processWrite(uint16_t addr, uint8_t* p_data, uint16_t length) {
             if (mem.attr[addr] & DXL_MEM_ATTR_EEPROM) {
                 EEPROM[addr] = mem.data[addr];
             }
-            /// Serial.printf("%02x ", p_data[i]);
+            // Serial.printf(" %02x", p_data[i]);
         }
         addr++;
     }
-    /// Serial.println(" ");
+    // Serial.println(" ");
 }
 
 
@@ -607,7 +607,7 @@ dxl_error_t write(dxl_t* p_dxl) {
         return DXL_RET_EMPTY;
     }
 
-    /// Serial.print(" write");
+    // Serial.print("[#] Processing");
 
     addr   = (p_dxl->rx.p_param[1] << 8) | p_dxl->rx.p_param[0];
     p_data = &p_dxl->rx.p_param[2];
@@ -616,23 +616,23 @@ dxl_error_t write(dxl_t* p_dxl) {
         length = p_dxl->rx.param_length - 2;
     }
     else {
-        /// Serial.println(" error");
+        // Serial.println(" invalid write command");
         dxlTxPacketStatus(p_dxl, p_dxl->id, DXL_ERR_DATA_LENGTH, NULL, 0);
         return DXL_RET_ERROR_LENGTH;
     }
 
     if (addr >= sizeof(dxl_mem_op3_t) || (addr + length) > sizeof(dxl_mem_op3_t)) {
-        /// Serial.println(" error");
+        // Serial.println(" invalid write command");
         dxlTxPacketStatus(p_dxl, p_dxl->id, DXL_ERR_ACCESS, NULL, 0);
         return DXL_RET_ERROR_LENGTH;
     }
     if (length > DXL_MAX_BUFFER - 10) {
-        /// Serial.println(" error");
+        // Serial.println(" invalid write command");
         dxlTxPacketStatus(p_dxl, p_dxl->id, DXL_ERR_DATA_LENGTH, NULL, 0);
         return DXL_RET_ERROR_LENGTH;
     }
 
-    /// Serial.println(" success");
+    // Serial.println(" valid write command");
 
     dxlTxPacketStatus(p_dxl, p_dxl->id, DXL_ERR_NONE, NULL, 0);
 

--- a/OpenCR/src/protocol/dxl_node_op3.cpp
+++ b/OpenCR/src/protocol/dxl_node_op3.cpp
@@ -461,14 +461,10 @@ void dxl_node_write_byte(uint16_t addr, uint8_t data) {
     }
 
     if (RANGE_CHECK(addr, p_dxl_mem->Buzzer)) {
-        if (p_dxl_mem->Buzzer > 0) {
+        if (p_dxl_mem->Buzzer > 0)
             tone(BDPIN_BUZZER, p_dxl_mem->Buzzer);
-            digitalWriteFast(HW_ALT_BUZZER_PIN, HIGH);
-        }
-        else {
+        else
             noTone(BDPIN_BUZZER);
-            digitalWriteFast(HW_ALT_BUZZER_PIN, LOW);
-        }
     }
 }
 

--- a/OpenCR/src/protocol/dxl_node_op3.cpp
+++ b/OpenCR/src/protocol/dxl_node_op3.cpp
@@ -68,7 +68,7 @@ void dxl_node_op3_init(void) {
     dxl_hw_op3_init();
     dxl_node_op3_reset();
 
-    if (p_dxl_mem->Model_Number != DXL_NODE_OP3_MODLE_NUMBER) {
+    if (p_dxl_mem->Model_Number != DXL_NODE_OP3_MODEL_NUMBER) {
         dxl_node_op3_factory_reset();
         dxl_node_op3_reset();
     }
@@ -220,7 +220,7 @@ void dxl_process_packet() {
         // waits to return the ping until either the ID before us returned, or
         // until we poll through all IDs waiting 3ms on each ID.
         case DXL_PROCESS_BROAD_PING:
-            // Recieve a packet if there's one waiting
+            // Receive a packet if there's one waiting
             dxl_ret = dxlRxPacket(&dxl_sp);
             // If it's a status packet, then that's almost certainly a ping from
             // a device before us in the queue
@@ -247,7 +247,7 @@ void dxl_process_packet() {
         // same story here as for ping, wait for other devices to return before
         // we do.
         case DXL_PROCESS_BROAD_READ:
-            // Recieve a packet if there's one waiting
+            // Receive a packet if there's one waiting
             dxl_ret = dxlRxPacket(&dxl_sp);
             // If it's a status packet, then that's almost certainly a the read
             // response from a device before us
@@ -271,7 +271,7 @@ void dxl_process_packet() {
                     /// Serial.println(dxl_sp.rx.id, HEX);
                 }
             }
-            // If we havent had a status packet in 50ms then timeout
+            // If we haven't had a status packet in 50ms then timeout
             else if (micros() - pre_time >= 50000) {
                 process_state = DXL_PROCESS_INST;
                 /// Serial.println(" Bulk Read timeout");
@@ -285,7 +285,7 @@ void dxl_process_packet() {
 
 
 /**
- * @brief Detect red button press and disable dymnamixel power.
+ * @brief Detect red button press and disable Dynamixel power.
  * @note Dynamixel power is never turned back on again, that must be done
  *       externally by the host device. (in our case, HardwareIO on the NUC)
  */
@@ -375,7 +375,7 @@ void dxl_node_op3_factory_reset(void) {
     uint16_t i;
 
 
-    p_dxl_mem->Model_Number        = DXL_NODE_OP3_MODLE_NUMBER;
+    p_dxl_mem->Model_Number        = DXL_NODE_OP3_MODEL_NUMBER;
     p_dxl_mem->Firmware_Version    = DXL_NODE_OP3_FW_VER;
     p_dxl_mem->ID                  = DXL_NODE_OP3_ID;
     p_dxl_mem->Baud                = DXL_NODE_OP3_BAUD;

--- a/OpenCR/src/protocol/dxl_node_op3.cpp
+++ b/OpenCR/src/protocol/dxl_node_op3.cpp
@@ -294,7 +294,7 @@ void dxl_node_op3_btn_loop(void) {
     if (dxl_hw_op3_button_read(DXL_POWER_DISABLE_BUTTON)) {
         /* Log if in debug mode and power is currently on */
         if (debug_state && dxl_node_read_byte(24))
-            Serial.print("DXL Power disabled");
+            Serial.println("[!] DXL Power disabled (red button pressed)");
         /* Control table 24 = DXL Power */
         dxl_node_write_byte(24, 0);
     }

--- a/OpenCR/src/protocol/dxl_node_op3.cpp
+++ b/OpenCR/src/protocol/dxl_node_op3.cpp
@@ -461,10 +461,14 @@ void dxl_node_write_byte(uint16_t addr, uint8_t data) {
     }
 
     if (RANGE_CHECK(addr, p_dxl_mem->Buzzer)) {
-        if (p_dxl_mem->Buzzer > 0)
+        if (p_dxl_mem->Buzzer > 0) {
             tone(BDPIN_BUZZER, p_dxl_mem->Buzzer);
-        else
+            digitalWriteFast(HW_ALT_BUZZER_PIN, HIGH);
+        }
+        else {
             noTone(BDPIN_BUZZER);
+            digitalWriteFast(HW_ALT_BUZZER_PIN, LOW);
+        }
     }
 }
 

--- a/OpenCR/src/protocol/dxl_node_op3.cpp
+++ b/OpenCR/src/protocol/dxl_node_op3.cpp
@@ -17,7 +17,7 @@
 #include "dxl.h"
 
 
-#define RANGE_CHECK(addr, x) dxl_node_check_range(addr, (uint32_t) & (x), sizeof(x))
+#define RANGE_CHECK(addr, data, x) dxl_node_check_range(addr, (uint32_t) & (x), sizeof(data), sizeof(x))
 
 
 static dxl_t dxl_sp;
@@ -49,7 +49,7 @@ void dxl_process_packet();
 static uint8_t dxl_node_read_byte(uint16_t addr);
 static void dxl_node_write_byte(uint16_t addr, uint8_t data);
 
-static BOOL dxl_node_check_range(uint16_t addr, uint32_t addr_ptr, uint8_t length);
+static BOOL dxl_node_check_range(uint16_t addr, uint32_t addr_ptr, uint8_t data_size, uint8_t field_size);
 void dxl_node_op3_change_baud(void);
 
 static void dxl_node_update_tx_rx_led();
@@ -424,14 +424,14 @@ void dxl_node_write_byte(uint16_t addr, uint8_t data) {
     mem.data[addr] = data;
 
 
-    if (RANGE_CHECK(addr, p_dxl_mem->Dynamixel_Power)) {
+    if (RANGE_CHECK(addr, data, p_dxl_mem->Dynamixel_Power)) {
         if (p_dxl_mem->Dynamixel_Power == 1)
             dxl_hw_power_enable();
         else
             dxl_hw_power_disable();
     }
 
-    if (RANGE_CHECK(addr, p_dxl_mem->LED)) {
+    if (RANGE_CHECK(addr, data, p_dxl_mem->LED)) {
         if (data & (1 << 0))
             dxl_hw_op3_led_set(PIN_LED_1, 0);
         else
@@ -446,7 +446,7 @@ void dxl_node_write_byte(uint16_t addr, uint8_t data) {
             dxl_hw_op3_led_set(PIN_LED_3, 1);
     }
 
-    if (RANGE_CHECK(addr, p_dxl_mem->LED_RGB)) {
+    if (RANGE_CHECK(addr, data, p_dxl_mem->LED_RGB)) {
         pwm_value[0] = (p_dxl_mem->LED_RGB >> 0) & 0x1F;
         pwm_value[1] = (p_dxl_mem->LED_RGB >> 5) & 0x1F;
         pwm_value[2] = (p_dxl_mem->LED_RGB >> 10) & 0x1F;
@@ -456,13 +456,13 @@ void dxl_node_write_byte(uint16_t addr, uint8_t data) {
         dxl_hw_op3_led_pwm(PIN_LED_B, pwm_value[2]);
     }
 
-    if (RANGE_CHECK(addr, p_dxl_mem->Baud)) {
+    if (RANGE_CHECK(addr, data, p_dxl_mem->Baud)) {
         dxl_node_op3_change_baud();
     }
 
-    if (RANGE_CHECK(addr, p_dxl_mem->Buzzer)) {
+    if (RANGE_CHECK(addr, data, p_dxl_mem->Buzzer)) {
         /* debug */
-        Serial.print("[#] Setting buzzer value from control table");
+        Serial.println("[#] Setting buzzer value from control table change");
 
         if (p_dxl_mem->Buzzer > 0)
             tone(BDPIN_BUZZER, p_dxl_mem->Buzzer);
@@ -479,40 +479,17 @@ void dxl_debug_write_byte_wrapper(uint16_t addr, uint8_t data) {
      TITLE   : dxl_node_check_range
      WORK    :
 ---------------------------------------------------------------------------*/
-BOOL dxl_node_check_range(uint16_t addr, uint32_t addr_ptr, uint8_t length) {
-
+BOOL dxl_node_check_range(uint16_t addr, uint32_t addr_ptr, uint8_t data_size, uint8_t field_size) {
     // Calculate the offset of the address in the control table
     uint32_t addr_offset = addr_ptr - (uint32_t) p_dxl_mem;
+    uint16_t addr_delta  = addr - addr_offset;
+    uint8_t size_delta   = field_size - data_size;
 
-    /* debug */
-    if (debug_state) {
-        Serial.print("[#] Checking range: ");
-        Serial.print(addr);
-        Serial.print(" @ 0x");
-        Serial.print(addr_ptr, HEX);
-        Serial.print(" (offset ");
-        Serial.print(addr_offset);
-        if (addr_offset < 10)
-            Serial.print(")  len ");
-        else
-            Serial.print(") len ");
-        Serial.println(length);
-    }
-
-    // Equivalent to:
-    //   length - <= (addr - addr_offset) < length
-    // i.e. addr is within the range of the control table value
-    if (addr >= (addr_offset + length - 1) && addr < (addr_offset + length)) {
-        /* debug */
-        if (debug_state)
-            Serial.println(" -> [#] PASS");
+    // Check that addr is within the range of the control table value
+    if (addr_delta >= 0 && addr_delta <= size_delta)
         return TRUE;
-    }
-
-    /* debug */
-    if (debug_state)
-        Serial.println(" -> [#] FAIL");
-    return FALSE;
+    else
+        return FALSE;
 }
 
 

--- a/OpenCR/src/protocol/dxl_node_op3.h
+++ b/OpenCR/src/protocol/dxl_node_op3.h
@@ -15,7 +15,7 @@
 
 /// @brief The Dynamixel ID of the OpenCR for packet communication
 #define DXL_NODE_OP3_ID           200  // 0xC8
-#define DXL_NODE_OP3_MODLE_NUMBER 0x7400
+#define DXL_NODE_OP3_MODEL_NUMBER 0x7400
 #define DXL_NODE_OP3_FW_VER       0x05
 /// @brief The factory default Baud Rate
 /// @details Value is indexed from {9600, 57600, 115200, 1000000, 2000000, 3000000, 4000000, 4500000}

--- a/OpenCR/src/protocol/dxl_node_op3.h
+++ b/OpenCR/src/protocol/dxl_node_op3.h
@@ -68,4 +68,6 @@ typedef struct {
 void dxl_node_op3_init(void);
 void dxl_node_op3_loop(void);
 
+void dxl_debug_write_byte_wrapper(uint16_t addr, uint8_t data);
+
 #endif

--- a/OpenCR/src/protocol/dxl_node_op3.h
+++ b/OpenCR/src/protocol/dxl_node_op3.h
@@ -16,7 +16,7 @@
 /// @brief The Dynamixel ID of the OpenCR for packet communication
 #define DXL_NODE_OP3_ID           200  // 0xC8
 #define DXL_NODE_OP3_MODLE_NUMBER 0x7400
-#define DXL_NODE_OP3_FW_VER       0x04
+#define DXL_NODE_OP3_FW_VER       0x05
 /// @brief The factory default Baud Rate
 /// @details Value is indexed from {9600, 57600, 115200, 1000000, 2000000, 3000000, 4000000, 4500000}
 /// @see dxl_hw_begin(baud) in ../hardware/dxl_hw.cpp


### PR DESCRIPTION
This PR:
- Fixes an issue where the buzzer does not sound when it should.
- Adds buzzer test functionality to the debug menu.
- Increments firmware version to `5` to reflect these changes.

The buzzer was broken as battery voltage monitoring called `noTone()` in the off state, which overrides any previous `tone()` calls which hadn't finished yet. The `noTone()` was redundant anyway because all `tone()`'s called within the voltage monitoring function had a duration set anyway.

Draft because it's late and I haven't tested it in a real robot, only with debug mode tests. 