### PR TITLE
Fix the timer crashing in NUSense

### DIFF
--- a/NUSense/Core/Src/dynamixel/Chain.hpp
+++ b/NUSense/Core/Src/dynamixel/Chain.hpp
@@ -154,6 +154,10 @@ namespace dynamixel {
             // Prepare the packet handler for the response packet.
             packet_handler.ready();
 
+            // Flush the port for any received bytes. Since we are starting a new request-response exchange, any bytes
+            // that happen to be in the buffer are not needed.
+            port.flush_rx();
+
             // Send the packet
             const uint16_t len = port.write(data);
 

--- a/NUSense/Core/Src/utility/support/MicrosecondTimer.hpp
+++ b/NUSense/Core/Src/utility/support/MicrosecondTimer.hpp
@@ -18,7 +18,7 @@ namespace utility::support {
          * @brief    Constructs the timer.
          * @param    htim the reference to the timer to be counted,
          */
-        MicrosecondTimer(TIM_HandleTypeDef* htim = &htim4) : htim(htim), threshold(0), is_counting(false) {}
+        MicrosecondTimer(TIM_HandleTypeDef* htim = &htim4) : htim(htim), start(0), timeout(0), is_counting(false) {}
 
         /**
          * @brief   Destructs the timer.
@@ -31,16 +31,14 @@ namespace utility::support {
          * @param   timeout the timeout in microseconds, at most 65535,
          * @return  whether the timer is ready, i.e. is not currently counting,
          */
-        bool begin(uint16_t timeout) {
+        bool begin(uint16_t input_timeout) {
             // If the timer is already counting, then return false before changing anything.
             if (is_counting)
                 return false;
 
-            // Get the current tick and calculate the necessary threshold.
-            uint16_t first_tick = __HAL_TIM_GET_COUNTER(htim);
-            threshold           = first_tick + timeout;
-            // The 16-bit overflow should handle wrapping.
-
+            // Get the current tick.
+            start       = __HAL_TIM_GET_COUNTER(htim);
+            timeout     = input_timeout;
             is_counting = true;
 
             return true;
@@ -57,9 +55,9 @@ namespace utility::support {
          * @brief   Restarts the timer.
          * @param   timeout the timeout in microseconds, at most 65535.
          */
-        void restart(uint16_t timeout) {
+        void restart(uint16_t input_timeout) {
             stop();
-            begin(timeout);
+            begin(input_timeout);
         }
 
         /**
@@ -70,27 +68,27 @@ namespace utility::support {
         inline bool has_timed_out() {
             // Copy the count-register of the timer so that it is stable for debugging.
             uint16_t count = __HAL_TIM_GET_COUNTER(htim);
-            if ((is_counting) && (count > threshold)) {
-                // This is a very hacky way to ignore overflowing on the sharp edge of the
-                // saw-tooth wave.
-                if (!((count - threshold) & 0x8000)) {
-                    // Since the timer has timed out, it is no longer counting.
-                    stop();
-                    return true;
-                }
-                else
-                    return false;
+            // If the time elapsed is greater than the timeout, then stop and return true.
+            // Only check this if the timer is counting so that the processor is not needlessly checking the inequality
+            // in a loop.
+            // The 16-bit arithmetic should handle overwrapping.
+            if ((is_counting) && (static_cast<uint16_t>(count - start) > timeout)) {
+                stop();
+                return true;
             }
-            else
+            else {
                 return false;
+            }
         }
 
-    private:
-        /// @brief  the handler of the peripheral timer,
+        // private:
+        /// @brief  The handler of the peripheral timer.
         TIM_HandleTypeDef* htim;
-        /// @brief  the threshold to compare the count thereagainst,
-        uint16_t threshold;
-        /// @brief  whether the timer is in use,
+        /// @brief  The time at which the count began.
+        uint16_t start;
+        /// @brief  The timeout to count towards.
+        uint16_t timeout;
+        /// @brief  Whether the timer is in use.
         bool is_counting;
     };
 

--- a/NUSense/Core/Src/utility/support/MicrosecondTimer.hpp
+++ b/NUSense/Core/Src/utility/support/MicrosecondTimer.hpp
@@ -81,7 +81,7 @@ namespace utility::support {
             }
         }
 
-        // private:
+    private:
         /// @brief  The handler of the peripheral timer.
         TIM_HandleTypeDef* htim;
         /// @brief  The time at which the count began.

--- a/NUSense/Core/Src/utility/support/MicrosecondTimer.hpp
+++ b/NUSense/Core/Src/utility/support/MicrosecondTimer.hpp
@@ -71,7 +71,8 @@ namespace utility::support {
             // If the time elapsed is greater than the timeout, then stop and return true.
             // Only check this if the timer is counting so that the processor is not needlessly checking the inequality
             // in a loop.
-            // The 16-bit arithmetic should handle overwrapping.
+            // The 16-bit arithmetic should handle overwrapping. E.g. if count = 0x1000, and start = 0x3000, then
+            // static_cast<uint16_t>(count - start) = 0xE000 which is the correct elapsed time.
             if ((is_counting) && (static_cast<uint16_t>(count - start) > timeout)) {
                 stop();
                 return true;

--- a/NUSense/Core/Src/utility/support/MillisecondTimer.hpp
+++ b/NUSense/Core/Src/utility/support/MillisecondTimer.hpp
@@ -67,7 +67,8 @@ namespace utility::support {
             // If the time elapsed is greater than the timeout, then stop and return true.
             // Only check this if the timer is counting so that the processor is not needlessly checking the inequality
             // in a loop.
-            // The 32-bit arithmetic should handle overwrapping.
+            // The 32-bit arithmetic should handle overwrapping. E.g. if count = 0x1000, and start = 0x3000, then
+            // static_cast<uint16_t>(count - start) = 0xE000 which is the correct elapsed time.
             if ((is_counting) && (static_cast<uint32_t>(count - start) > timeout)) {
                 stop();
                 return true;

--- a/NUSense/Core/Src/utility/support/MillisecondTimer.hpp
+++ b/NUSense/Core/Src/utility/support/MillisecondTimer.hpp
@@ -14,7 +14,7 @@ namespace utility::support {
         /**
          * @brief    Constructs the timer.
          */
-        MillisecondTimer() : threshold(0), is_counting(false) {}
+        MillisecondTimer() : start(0), timeout(0), is_counting(false) {}
 
         /**
          * @brief   Destructs the timer.
@@ -24,19 +24,17 @@ namespace utility::support {
 
         /**
          * @brief   Begins the timer.
-         * @param   timeout the timeout in microseconds, at most 4294967295,
+         * @param   timeout the timeout in milliseconds, at most 4294967295,
          * @return  whether the timer is ready, i.e. is not currently counting,
          */
-        bool begin(uint32_t timeout) {
+        bool begin(uint32_t input_timeout) {
             // If the timer is already counting, then return false before changing anything.
             if (is_counting)
                 return false;
 
-            // Get the current tick and calculate the necessary threshold.
-            uint32_t first_tick = HAL_GetTick();
-            threshold           = first_tick + timeout;
-            // The 32-bit overflow should handle wrapping.
-
+            // Get the current tick.
+            start       = HAL_GetTick();
+            timeout     = input_timeout;
             is_counting = true;
 
             return true;
@@ -50,32 +48,41 @@ namespace utility::support {
         }
 
         /**
+         * @brief   Restarts the timer.
+         * @param   timeout the timeout in milliseconds, at most 4294967295.
+         */
+        void restart(uint16_t input_timeout) {
+            stop();
+            begin(input_timeout);
+        }
+
+        /**
          * @brief   Sees whether the timer has timed out.
          * @note    This should be kept very short.
          * @return  whether the timer has timed out,
          */
         inline bool has_timed_out() {
             // Copy the count-register of the timer so that it is stable for debugging.
-            uint32_t count = HAL_GetTick();
-            if ((is_counting) && (count > threshold)) {
-                // This is a very hacky way to ignore overflowing on the sharp edge of the
-                // saw-tooth wave.
-                if (!((count - threshold) & 0x80000000)) {
-                    // Since the timer has timed out, it is no longer counting.
-                    is_counting = false;
-                    return true;
-                }
-                else
-                    return false;
+            uint16_t count = HAL_GetTick();
+            // If the time elapsed is greater than the timeout, then stop and return true.
+            // Only check this if the timer is counting so that the processor is not needlessly checking the inequality
+            // in a loop.
+            // The 32-bit arithmetic should handle overwrapping.
+            if ((is_counting) && (static_cast<uint32_t>(count - start) > timeout)) {
+                stop();
+                return true;
             }
-            else
+            else {
                 return false;
+            }
         }
 
     private:
-        /// @brief  the threshold to compare the count thereagainst,
-        uint32_t threshold;
-        /// @brief  whether the timer is in use,
+        /// @brief  The time at which the count began.
+        uint16_t start;
+        /// @brief  The timeout to count towards.
+        uint16_t timeout;
+        /// @brief  Whether the timer is in use.
         bool is_counting;
     };
 


### PR DESCRIPTION
### Brief

Reworks the timeout logic in both the `MicrosecondTimer` and the `MillisecondTimer` so that the timer doesn't break when the counter is near the maximum value.

As a smaller secondary change, the RX buffer was flushed before sending a new request/instruction to make the Dynamixel communications more robust.

### Problem

When a servo was unplugged, the original logic worked mostly fine until around every 4 s, and the timer would have frozen temporarily for a bit and then recovered. This would have repeated every 4 s or so. Given that the count is a 16-bit integer, I believe that the bug was when the threshold was just under 2^16-1, the count register wraps over 2^16, making `count > threshold` always false until the count catches back up.

![image](https://github.com/user-attachments/assets/af7bd18f-b6c5-42c1-82af-adceaf73a1bc)

As seen above, the activity on the Dynamixel bus temporarily drops out for a bit every 4 s or so.

### Context

When I originally wrote the underlying logic for the timeout, I tried to cleverly use some hacky arithmetic to make the code fast and simple. This was since the timeout would be checked many times within the main loop. However, it created a bug and ended up being too confusing to troubeshoot. So, I have changed it to explicitly compare a straightforward elapsed time. This has also fixed the bug in the process. It is also not really that many more instructions; so, it should still be quick.

Even as I read back over the original code, which I wrote a while ago, I find it a bit confusing and cannot really remember why I made it like that. It may even be salvagable if I ponder some more over how the signedness works, but it is far better to just rewrite the logic explicitly as an elapsed time.