### PR TITLE
Resend the previous data to the NUC if no new data was received from the servos.

### DIFF
--- a/NUSense/Core/Src/nusense/NUSenseIO/send_nusense_data.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/send_nusense_data.cpp
@@ -51,6 +51,8 @@ namespace nusense {
                 nusense_msg.servo_map[i].value.voltage     = servo_states[i].voltage / servo_states[i].filter_count;
                 nusense_msg.servo_map[i].value.temperature = servo_states[i].temperature / servo_states[i].filter_count;
             }
+
+            // If any of these are filtered in later revisions of the code, then move them under the above if-condition.
             nusense_msg.servo_map[i].value.goal_pwm      = servo_states[i].goal_pwm;
             nusense_msg.servo_map[i].value.goal_current  = servo_states[i].goal_current;
             nusense_msg.servo_map[i].value.goal_velocity = servo_states[i].goal_velocity;

--- a/NUSense/Core/Src/nusense/NUSenseIO/send_nusense_data.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/send_nusense_data.cpp
@@ -31,34 +31,41 @@ namespace nusense {
         nusense_msg.servo_map_count = NUMBER_OF_DEVICES;
 
         for (size_t i = 0; i < NUMBER_OF_DEVICES; ++i) {
-            nusense_msg.servo_map[i].key       = i;
-            nusense_msg.servo_map[i].has_value = true;
+            // If no new data have been accumulated in the filter, then keep the existing values in the message.
+            if (servo_states[i].filter_count != 0.0) {
+                nusense_msg.servo_map[i].key       = i;
+                nusense_msg.servo_map[i].has_value = true;
 
-            nusense_msg.servo_map[i].value.id             = i + 1;
-            nusense_msg.servo_map[i].value.hardware_error = servo_states[i].hardware_error;
-            nusense_msg.servo_map[i].value.torque_enabled = servo_states[i].torque_enabled;
+                nusense_msg.servo_map[i].value.id             = i + 1;
+                nusense_msg.servo_map[i].value.hardware_error = servo_states[i].hardware_error;
+                nusense_msg.servo_map[i].value.torque_enabled = servo_states[i].torque_enabled;
 
-            nusense_msg.servo_map[i].value.present_pwm = servo_states[i].present_pwm / servo_states[i].filter_count;
-            nusense_msg.servo_map[i].value.present_current =
-                servo_states[i].present_current / servo_states[i].filter_count;
-            nusense_msg.servo_map[i].value.present_velocity =
-                servo_states[i].present_velocity / servo_states[i].filter_count;
-            nusense_msg.servo_map[i].value.present_position = servo_states[i].mean_present_position.get_mean();
+                nusense_msg.servo_map[i].value.present_pwm = servo_states[i].present_pwm / servo_states[i].filter_count;
+                nusense_msg.servo_map[i].value.present_current =
+                    servo_states[i].present_current / servo_states[i].filter_count;
+                nusense_msg.servo_map[i].value.present_velocity =
+                    servo_states[i].present_velocity / servo_states[i].filter_count;
+                nusense_msg.servo_map[i].value.present_position = servo_states[i].mean_present_position.get_mean();
+                volatile uint8_t frederic_chopin                = 0;
+                if (nusense_msg.servo_map[i].value.present_position == 0.0) {
+                    frederic_chopin = 1;
+                }
 
-            nusense_msg.servo_map[i].value.goal_pwm      = servo_states[i].goal_pwm;
-            nusense_msg.servo_map[i].value.goal_current  = servo_states[i].goal_current;
-            nusense_msg.servo_map[i].value.goal_velocity = servo_states[i].goal_velocity;
-            nusense_msg.servo_map[i].value.goal_position = servo_states[i].goal_position;
+                nusense_msg.servo_map[i].value.goal_pwm      = servo_states[i].goal_pwm;
+                nusense_msg.servo_map[i].value.goal_current  = servo_states[i].goal_current;
+                nusense_msg.servo_map[i].value.goal_velocity = servo_states[i].goal_velocity;
+                nusense_msg.servo_map[i].value.goal_position = servo_states[i].goal_position;
 
-            nusense_msg.servo_map[i].value.voltage     = servo_states[i].voltage / servo_states[i].filter_count;
-            nusense_msg.servo_map[i].value.temperature = servo_states[i].temperature / servo_states[i].filter_count;
+                nusense_msg.servo_map[i].value.voltage     = servo_states[i].voltage / servo_states[i].filter_count;
+                nusense_msg.servo_map[i].value.temperature = servo_states[i].temperature / servo_states[i].filter_count;
 
-            nusense_msg.servo_map[i].value.has_packet_counts = true;
-            nusense_msg.servo_map[i].value.packet_counts.total =
-                servo_states[i].num_successes + servo_states[i].num_crc_errors + servo_states[i].num_packet_errors;
-            nusense_msg.servo_map[i].value.packet_counts.timeouts      = servo_states[i].num_timeouts;
-            nusense_msg.servo_map[i].value.packet_counts.crc_errors    = servo_states[i].num_crc_errors;
-            nusense_msg.servo_map[i].value.packet_counts.packet_errors = servo_states[i].num_packet_errors;
+                nusense_msg.servo_map[i].value.has_packet_counts = true;
+                nusense_msg.servo_map[i].value.packet_counts.total =
+                    servo_states[i].num_successes + servo_states[i].num_crc_errors + servo_states[i].num_packet_errors;
+                nusense_msg.servo_map[i].value.packet_counts.timeouts      = servo_states[i].num_timeouts;
+                nusense_msg.servo_map[i].value.packet_counts.crc_errors    = servo_states[i].num_crc_errors;
+                nusense_msg.servo_map[i].value.packet_counts.packet_errors = servo_states[i].num_packet_errors;
+            }
         }
 
         // Once everything else is filled we send it to the NUC. Just overwrite the bytes within encoding_payload

--- a/NUSense/Core/Src/nusense/NUSenseIO/send_nusense_data.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/send_nusense_data.cpp
@@ -31,12 +31,13 @@ namespace nusense {
         nusense_msg.servo_map_count = NUMBER_OF_DEVICES;
 
         for (size_t i = 0; i < NUMBER_OF_DEVICES; ++i) {
+            nusense_msg.servo_map[i].key       = i;
+            nusense_msg.servo_map[i].has_value = true;
+
+            nusense_msg.servo_map[i].value.id = i + 1;
+
             // If no new data have been accumulated in the filter, then keep the existing values in the message.
             if (servo_states[i].filter_count != 0.0) {
-                nusense_msg.servo_map[i].key       = i;
-                nusense_msg.servo_map[i].has_value = true;
-
-                nusense_msg.servo_map[i].value.id             = i + 1;
                 nusense_msg.servo_map[i].value.hardware_error = servo_states[i].hardware_error;
                 nusense_msg.servo_map[i].value.torque_enabled = servo_states[i].torque_enabled;
 
@@ -46,26 +47,21 @@ namespace nusense {
                 nusense_msg.servo_map[i].value.present_velocity =
                     servo_states[i].present_velocity / servo_states[i].filter_count;
                 nusense_msg.servo_map[i].value.present_position = servo_states[i].mean_present_position.get_mean();
-                volatile uint8_t frederic_chopin                = 0;
-                if (nusense_msg.servo_map[i].value.present_position == 0.0) {
-                    frederic_chopin = 1;
-                }
-
-                nusense_msg.servo_map[i].value.goal_pwm      = servo_states[i].goal_pwm;
-                nusense_msg.servo_map[i].value.goal_current  = servo_states[i].goal_current;
-                nusense_msg.servo_map[i].value.goal_velocity = servo_states[i].goal_velocity;
-                nusense_msg.servo_map[i].value.goal_position = servo_states[i].goal_position;
 
                 nusense_msg.servo_map[i].value.voltage     = servo_states[i].voltage / servo_states[i].filter_count;
                 nusense_msg.servo_map[i].value.temperature = servo_states[i].temperature / servo_states[i].filter_count;
-
-                nusense_msg.servo_map[i].value.has_packet_counts = true;
-                nusense_msg.servo_map[i].value.packet_counts.total =
-                    servo_states[i].num_successes + servo_states[i].num_crc_errors + servo_states[i].num_packet_errors;
-                nusense_msg.servo_map[i].value.packet_counts.timeouts      = servo_states[i].num_timeouts;
-                nusense_msg.servo_map[i].value.packet_counts.crc_errors    = servo_states[i].num_crc_errors;
-                nusense_msg.servo_map[i].value.packet_counts.packet_errors = servo_states[i].num_packet_errors;
             }
+            nusense_msg.servo_map[i].value.goal_pwm      = servo_states[i].goal_pwm;
+            nusense_msg.servo_map[i].value.goal_current  = servo_states[i].goal_current;
+            nusense_msg.servo_map[i].value.goal_velocity = servo_states[i].goal_velocity;
+            nusense_msg.servo_map[i].value.goal_position = servo_states[i].goal_position;
+
+            nusense_msg.servo_map[i].value.has_packet_counts = true;
+            nusense_msg.servo_map[i].value.packet_counts.total =
+                servo_states[i].num_successes + servo_states[i].num_crc_errors + servo_states[i].num_packet_errors;
+            nusense_msg.servo_map[i].value.packet_counts.timeouts      = servo_states[i].num_timeouts;
+            nusense_msg.servo_map[i].value.packet_counts.crc_errors    = servo_states[i].num_crc_errors;
+            nusense_msg.servo_map[i].value.packet_counts.packet_errors = servo_states[i].num_packet_errors;
         }
 
         // Once everything else is filled we send it to the NUC. Just overwrite the bytes within encoding_payload


### PR DESCRIPTION
### Brief

Does not update the filtered servo-data (e.g. present position) in the nanopb message if the filter-count is zero, i.e. if no new data was received from the servos.

This is a compromise before a proper filter is implemented.

### Context

Some of the data received from the servos is averaged between transmissions to the NUC. This is a crude way of downsampling from a variable asynchronous polling rate to a consistent 100 Hz.

Originally, when no new data was received from the servos, the fields in the nanopb message would be set to zero. This would happen rarely for some servos when servo-targets were being sent to NUSense, e.g. during KeyboardWalk, and the Dynamixel bus had a lot of activity. 

However rare it was, it would nonetheless yield a spike at zero in the data, as seen for the servo present position below. Note that healthy packet count is the number of response-packets with servo-data. (The firmware has been altered slightly for this test.) Whenever it is zero, that means that the Dynamixel bus is too busy, and the filter-count is zero.

![image](https://github.com/user-attachments/assets/53d29916-79d3-4e86-b81d-c860b53c2ea7)

If the filter-count is zero, but the nanopb fields are not assigned, then they are kept to their previous filtered values instead of zero. As seen below, there are no spikes at zero for the servo present position.

![image](https://github.com/user-attachments/assets/14588d76-152f-498f-acad-dddfbb8decba)