### PR TITLE
Convert the acceleration to the correct SI units; add a delay to fix SPI writes.

### DIFF
--- a/NUSense/Core/Src/imu.cpp
+++ b/NUSense/Core/Src/imu.cpp
@@ -39,6 +39,7 @@ namespace nusense {
         write_reg(Address::PWR_MGMT_1, PWR_MGMT_1_DEVICE_RESET | PWR_MGMT_1_CLKSEL_AUTO);
         HAL_Delay(1);
         write_reg(Address::PWR_MGMT_1, PWR_MGMT_1_CLKSEL_AUTO);
+        HAL_Delay(10);
 
         // Make sure that we are in SPI-mode.
         write_reg(Address::USER_CTRL,
@@ -187,17 +188,17 @@ namespace nusense {
                                                    .z = static_cast<int16_t>(gyro.z.l | (gyro.z.h << 8))}};
         // convert from big to little endian and then scale
         converted_data->accelerometer.x =
-            static_cast<float>(combined.accelerometer.x) / ACCEL_SENSITIVITY_CHOSEN / 2 * 9.8;
+            static_cast<float>(combined.accelerometer.x) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
         converted_data->accelerometer.y =
-            static_cast<float>(combined.accelerometer.y) / ACCEL_SENSITIVITY_CHOSEN / 2 * 9.8;
+            static_cast<float>(combined.accelerometer.y) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
         converted_data->accelerometer.z =
-            static_cast<float>(combined.accelerometer.z) / ACCEL_SENSITIVITY_CHOSEN / 2 * 9.8;
+            static_cast<float>(combined.accelerometer.z) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
         converted_data->gyroscope.x =
-            static_cast<float>(combined.gyroscope.x) / GYRO_SENSITIVITY_CHOSEN / 2 * M_PI / 180.0;
+            static_cast<float>(combined.gyroscope.x) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
         converted_data->gyroscope.y =
-            static_cast<float>(combined.gyroscope.y) / GYRO_SENSITIVITY_CHOSEN / 2 * M_PI / 180.0;
+            static_cast<float>(combined.gyroscope.y) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
         converted_data->gyroscope.z =
-            static_cast<float>(combined.gyroscope.z) / GYRO_SENSITIVITY_CHOSEN / 2 * M_PI / 180.0;
+            static_cast<float>(combined.gyroscope.z) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
         converted_data->temperature = (static_cast<float>(combined.temperature) - ROOM_TEMP_OFFSET) / TEMP_SENSITIVITY
                                       + 25.0;  // from Section-11.25 from the datasheet
     }

--- a/NUSense/Core/Src/imu.cpp
+++ b/NUSense/Core/Src/imu.cpp
@@ -187,13 +187,15 @@ namespace nusense {
                                  .gyroscope     = {.x = static_cast<int16_t>(gyro.x.l | (gyro.x.h << 8)),
                                                    .y = static_cast<int16_t>(gyro.y.l | (gyro.y.h << 8)),
                                                    .z = static_cast<int16_t>(gyro.z.l | (gyro.z.h << 8))}};
-        // convert from big to little endian and then scale
+        // Convert the acceleration from bits, to g's, and then to ms^-2.
         converted_data->accelerometer.x = static_cast<float>(combined.accelerometer.x) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
         converted_data->accelerometer.y = static_cast<float>(combined.accelerometer.y) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
         converted_data->accelerometer.z = static_cast<float>(combined.accelerometer.z) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
+        // Convert the rotational speed from bits, to deg/s, and then to rad/s.
         converted_data->gyroscope.x = static_cast<float>(combined.gyroscope.x) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
         converted_data->gyroscope.y = static_cast<float>(combined.gyroscope.y) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
         converted_data->gyroscope.z = static_cast<float>(combined.gyroscope.z) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
+        // Convert the temperature according to the formula in the datasheet.
         converted_data->temperature = (static_cast<float>(combined.temperature) - ROOM_TEMP_OFFSET) / TEMP_SENSITIVITY
                                       + 25.0;  // from Section-11.25 from the datasheet
     }

--- a/NUSense/Core/Src/imu.cpp
+++ b/NUSense/Core/Src/imu.cpp
@@ -186,12 +186,18 @@ namespace nusense {
                                                    .y = static_cast<int16_t>(gyro.y.l | (gyro.y.h << 8)),
                                                    .z = static_cast<int16_t>(gyro.z.l | (gyro.z.h << 8))}};
         // convert from big to little endian and then scale
-        converted_data->accelerometer.x = static_cast<float>(combined.accelerometer.x) / ACCEL_SENSITIVITY_CHOSEN;
-        converted_data->accelerometer.y = static_cast<float>(combined.accelerometer.y) / ACCEL_SENSITIVITY_CHOSEN;
-        converted_data->accelerometer.z = static_cast<float>(combined.accelerometer.z) / ACCEL_SENSITIVITY_CHOSEN;
-        converted_data->gyroscope.x = static_cast<float>(combined.gyroscope.x) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
-        converted_data->gyroscope.y = static_cast<float>(combined.gyroscope.y) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
-        converted_data->gyroscope.z = static_cast<float>(combined.gyroscope.z) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
+        converted_data->accelerometer.x =
+            static_cast<float>(combined.accelerometer.x) / ACCEL_SENSITIVITY_CHOSEN / 2 * 9.8;
+        converted_data->accelerometer.y =
+            static_cast<float>(combined.accelerometer.y) / ACCEL_SENSITIVITY_CHOSEN / 2 * 9.8;
+        converted_data->accelerometer.z =
+            static_cast<float>(combined.accelerometer.z) / ACCEL_SENSITIVITY_CHOSEN / 2 * 9.8;
+        converted_data->gyroscope.x =
+            static_cast<float>(combined.gyroscope.x) / GYRO_SENSITIVITY_CHOSEN / 2 * M_PI / 180.0;
+        converted_data->gyroscope.y =
+            static_cast<float>(combined.gyroscope.y) / GYRO_SENSITIVITY_CHOSEN / 2 * M_PI / 180.0;
+        converted_data->gyroscope.z =
+            static_cast<float>(combined.gyroscope.z) / GYRO_SENSITIVITY_CHOSEN / 2 * M_PI / 180.0;
         converted_data->temperature = (static_cast<float>(combined.temperature) - ROOM_TEMP_OFFSET) / TEMP_SENSITIVITY
                                       + 25.0;  // from Section-11.25 from the datasheet
     }

--- a/NUSense/Core/Src/imu.cpp
+++ b/NUSense/Core/Src/imu.cpp
@@ -35,10 +35,11 @@ namespace nusense {
     void IMU::init() {
         // Select the first PLL as the clock and do a soft reset.
         // This may fix the problem of the power-up sequence in Section-4.19 of the IMU's datasheet.
-        // write_reg(Address::PWR_MGMT_1,     PWR_MGMT_1_CLKSEL_AUTO);
         write_reg(Address::PWR_MGMT_1, PWR_MGMT_1_DEVICE_RESET | PWR_MGMT_1_CLKSEL_AUTO);
         HAL_Delay(1);
+        // Ensure that the first PLL is chosen.
         write_reg(Address::PWR_MGMT_1, PWR_MGMT_1_CLKSEL_AUTO);
+        // For some reason, a delay of at least 1 ms is needed afterwards lest the registers are not written to.
         HAL_Delay(10);
 
         // Make sure that we are in SPI-mode.

--- a/NUSense/Core/Src/imu.cpp
+++ b/NUSense/Core/Src/imu.cpp
@@ -187,18 +187,12 @@ namespace nusense {
                                                    .y = static_cast<int16_t>(gyro.y.l | (gyro.y.h << 8)),
                                                    .z = static_cast<int16_t>(gyro.z.l | (gyro.z.h << 8))}};
         // convert from big to little endian and then scale
-        converted_data->accelerometer.x =
-            static_cast<float>(combined.accelerometer.x) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
-        converted_data->accelerometer.y =
-            static_cast<float>(combined.accelerometer.y) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
-        converted_data->accelerometer.z =
-            static_cast<float>(combined.accelerometer.z) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
-        converted_data->gyroscope.x =
-            static_cast<float>(combined.gyroscope.x) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
-        converted_data->gyroscope.y =
-            static_cast<float>(combined.gyroscope.y) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
-        converted_data->gyroscope.z =
-            static_cast<float>(combined.gyroscope.z) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
+        converted_data->accelerometer.x = static_cast<float>(combined.accelerometer.x) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
+        converted_data->accelerometer.y = static_cast<float>(combined.accelerometer.y) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
+        converted_data->accelerometer.z = static_cast<float>(combined.accelerometer.z) / ACCEL_SENSITIVITY_CHOSEN * 9.8;
+        converted_data->gyroscope.x = static_cast<float>(combined.gyroscope.x) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
+        converted_data->gyroscope.y = static_cast<float>(combined.gyroscope.y) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
+        converted_data->gyroscope.z = static_cast<float>(combined.gyroscope.z) / GYRO_SENSITIVITY_CHOSEN * M_PI / 180.0;
         converted_data->temperature = (static_cast<float>(combined.temperature) - ROOM_TEMP_OFFSET) / TEMP_SENSITIVITY
                                       + 25.0;  // from Section-11.25 from the datasheet
     }


### PR DESCRIPTION
### Brief

- Converts the accelerometer to ms^-2 instead of g to match the main codebase.
- Adds a 10-ms delay after setting the IMU's clock-source lest it ignores writing to the registers.

### Problem

For whatever reason unbeknown to me, the IMU registers will not be written to unless there is a delay after setting the clock-source in the `PWR_MGMT_1` register. 

Originally, this problem manifested itself where the accelerometer values were half of what were expected. Reading back the `ACCEL_CONFIG` register, it was revealed that it was still at the reset value, i.e. set to ±2 g, instead of the chosen ±4 g.

I found out that a delay was needed when I was debugging with breakpoints in `IMU::init`. If I had a breakpoint before the `ACCEL_CONFIG2` register was written to, then the register would have the correct value, and the accelerometer would have the expected values.

### Solution

I pin-pointed the spot at which the delay needed to be. It needed to be after the second writing of the `PWR_MGMT_1` register. Initially, a delay of 1 ms seemed to work. So, I made it an order of magnitude longer to be sure, i.e. 10 ms.

I cannot find anywhere in the datasheet that says that this is needed. The only specification like it is that the startup time for the register read/write ([page-12](https://invensense.tdk.com/wp-content/uploads/2021/03/DS-000143-ICM-20689-TYP-v1.1.pdf)) needs to be at least 5 ms from sleep and 100 ms from power-up. However, there is already a 1-s delay before `IMU::init`. Otherwise, it may be that the soft-reset at the very start of `IMU::init` counts as 'sleep'. If so, then that may be the reason.

Any answers and theories as to why are welcome.