### PR TITLE
Introduces controllability of the LEDs and the Buzzer.

### DIFF
--- a/NUSense/Core/Src/device/Buzzer.hpp
+++ b/NUSense/Core/Src/device/Buzzer.hpp
@@ -1,3 +1,4 @@
+#include "Pulser.hpp"
 #include "stm32h753xx.h"
 
 #ifndef DEVICE_BUZZER_HPP
@@ -6,11 +7,11 @@
 namespace device {
 
     /**
-     * @brief   The buzzer.
+     * @brief   The buzzer which is a pulser.
      * @note    This is an exercise for the author in bare-metal programming with the SFRs. Let me
      *          know if there are any better C++ paradigms for SFRs.
      */
-    class Buzzer {
+    class Buzzer : public Pulser {
     public:
         /**
          * @brief    Constructs the buzzer.
@@ -34,17 +35,24 @@ namespace device {
 
         /**
          * @brief   Turns the buzzer on.
-         * @note    May introduce beaps and modulated frequencies later.
+         * @note    May introduce modulated frequencies later. Since the buzzer is only on and off
+         *          with a single frequency, different frequencies cannot be done like the OpenCR,
+         *          at least not purely. However, different frequencies may be spoofed by
+         *          modulating around the centre-frequency with a square wave. Technically, this
+         *          would make a dual-tone, but the higher tone may be pushed to the ultrasonic
+         *          band.
          */
         inline void turn_on() {
             port->BSRR = 1 << pin;
+            Pulser::turn_on();
         }
 
         /**
          * @brief   Turns the buzzer off.
          */
         inline void turn_off() {
-            port->BSRR = static_cast<uint32_t>(1 << (pin * 2));
+            port->BSRR = static_cast<uint32_t>(1 << (pin + 16));
+            Pulser::turn_off();
         }
 
     private:

--- a/NUSense/Core/Src/device/Buzzer.hpp
+++ b/NUSense/Core/Src/device/Buzzer.hpp
@@ -19,9 +19,6 @@ namespace device {
          * @param    pin The pin at which the buzzer is connected.
          */
         Buzzer(GPIO_TypeDef* port, uint16_t pin) : port(port), pin(pin) {
-            // Set the resistors to pull up.
-            port->PUPDR &= ~(0b11 << (pin * 2));
-            port->PUPDR |= (0b01 << (pin * 2));
             // Set the pin as an output.
             port->MODER |= (0b01 << (pin * 2));
             port->MODER &= ~(0b10 << (pin * 2));
@@ -42,7 +39,7 @@ namespace device {
          *          would make a dual-tone, but the higher tone may be pushed to the ultrasonic
          *          band.
          */
-        inline void turn_on() {
+        inline void turn_on() override {
             port->BSRR = 1 << pin;
             Pulser::turn_on();
         }
@@ -50,16 +47,16 @@ namespace device {
         /**
          * @brief   Turns the buzzer off.
          */
-        inline void turn_off() {
+        inline void turn_off() override {
             port->BSRR = static_cast<uint32_t>(1 << (pin + 16));
             Pulser::turn_off();
         }
 
     private:
         /// @brief  The handler of the peripheral port.
-        GPIO_TypeDef* port;
+        GPIO_TypeDef* port = NULL;
         /// @brief  The pin.
-        uint16_t pin;
+        uint16_t pin = 0;
     };
 
 }  // namespace device

--- a/NUSense/Core/Src/device/Buzzer.hpp
+++ b/NUSense/Core/Src/device/Buzzer.hpp
@@ -32,12 +32,7 @@ namespace device {
 
         /**
          * @brief   Turns the buzzer on.
-         * @note    May introduce modulated frequencies later. Since the buzzer is only on and off
-         *          with a single frequency, different frequencies cannot be done like the OpenCR,
-         *          at least not purely. However, different frequencies may be spoofed by
-         *          modulating around the centre-frequency with a square wave. Technically, this
-         *          would make a dual-tone, but the higher tone may be pushed to the ultrasonic
-         *          band.
+         * @note    May introduce modulated frequencies later with a timer.
          */
         inline void turn_on() override {
             port->BSRR = 1 << pin;

--- a/NUSense/Core/Src/device/Pulser.hpp
+++ b/NUSense/Core/Src/device/Pulser.hpp
@@ -32,7 +32,7 @@ namespace device {
         /**
          * @brief   Gets the current priority.
          */
-        inline const Priority get_current_priority() const {
+        inline Priority get_current_priority() const {
             return current_priority;
         }
 
@@ -45,9 +45,9 @@ namespace device {
          * @return  Whether the new pulsing task has been taken in, i.e. the priority is high
          *          enough.
          */
-        inline const bool pulse(const uint8_t num_pulses    = 1,
-                                const bool is_repeating     = false,
-                                const Priority new_priority = LOW) {
+        inline bool pulse(const uint8_t num_pulses    = 1,
+                          const bool is_repeating     = false,
+                          const Priority new_priority = LOW) {
             // If the wanted priority is less than the current priority, then return early.
             if (new_priority < current_priority) {
                 return false;
@@ -60,7 +60,7 @@ namespace device {
 
             // Store the number of pulses if repeating.
             num_pulses_left = num_pulses;
-            if (is_repeating == true) {
+            if (is_repeating) {
                 num_pulses_in_burst = num_pulses;
             }
             else {
@@ -96,7 +96,7 @@ namespace device {
             // If there are still pulses left to do, and the half-pause has timed out, then toggle
             // the output.
             if ((num_pulses_left != 0) && (halfpulse_timer.has_timed_out())) {
-                if (is_on == true) {
+                if (is_on) {
                     // If this is a falling edge, then a full pulse has been done, and decrease the
                     // number of pulses left.
                     num_pulses_left--;

--- a/NUSense/Core/Src/device/Pulser.hpp
+++ b/NUSense/Core/Src/device/Pulser.hpp
@@ -146,6 +146,17 @@ namespace device {
             }
         }
 
+        /**
+         * @brief   Stops the current pulsing task if any.
+         */
+        void stop() {
+            halfpulse_timer.stop();
+            num_pulses_left = 0;
+            num_pulses_in_burst = 0;
+            turn_off();
+            current_priority = NONE;
+        }
+
     private:
         /// @brief  The state of the device, i.e. the output.
         bool is_on = false;

--- a/NUSense/Core/Src/device/Pulser.hpp
+++ b/NUSense/Core/Src/device/Pulser.hpp
@@ -39,6 +39,8 @@ namespace device {
         /**
          * @brief   Pulses the device.
          * @note    This should ideally not be overridden.
+         * @note    The priority is a basic way to stop calls overwriting important pulses like
+         *          the one for overheating. It does not queue or shelved tasks.
          * @param   num_pulses The number of pulses to show.
          * @param   is_repeating Whether the burst of pulses is repeating with some dead time in
          *          between each.

--- a/NUSense/Core/Src/device/Pulser.hpp
+++ b/NUSense/Core/Src/device/Pulser.hpp
@@ -1,0 +1,152 @@
+#ifndef DEVICE_PULSER_HPP
+#define DEVICE_PULSER_HPP
+
+#include "../utility/support/MillisecondTimer.hpp"
+
+namespace device {
+
+    /// @brief  The half period of a pulse in milliseconds.
+    static constexpr uint16_t HALFPULSE_PERIOD = 500;
+    /// @brief  The time between burst of pulses in milliseconds if the pulser is repeating.
+    static constexpr uint16_t DEAD_PERIOD = 2000;
+
+    /**
+     * @brief   The pulser.
+     */
+    class Pulser {
+    public:
+        /// @brief  The levels priority of the pulsing routine if any.
+        enum Priority { NONE = 0, LOW = 1, MID = 2, HIGH = 3 };
+
+        /**
+         * @brief    Constructs the pulser.
+         */
+        Pulser() {}
+
+        /**
+         * @brief   Destructs the pulser.
+         * @note    Nothing needs to be freed as of yet.
+         */
+        virtual ~Pulser() {}
+
+        /**
+         * @brief   Gets the current priority.
+         */
+        inline const Priority get_current_priority() const {
+            return current_priority;
+        }
+
+        /**
+         * @brief   Pulses the device.
+         * @note    This should ideally not be overridden.
+         * @param   num_pulses The number of pulses to show.
+         * @param   is_repeating Whether the burst of pulses is repeating with some dead time in
+         *          between each.
+         * @return  Whether the new pulsing task has been taken in, i.e. the priority is high
+         *          enough.
+         */
+        inline const bool pulse(const uint8_t num_pulses    = 1,
+                                const bool is_repeating     = false,
+                                const Priority new_priority = LOW) {
+            // If the wanted priority is less than the current priority, then return early.
+            if (new_priority < current_priority) {
+                return false;
+            }
+            current_priority = new_priority;
+
+            // Begin the timer for the first half-pause, i.e. the off-period.
+            halfpulse_timer.begin(HALFPULSE_PERIOD);
+            turn_off();
+
+            // Store the number of pulses if repeating.
+            num_pulses_left = num_pulses;
+            if (is_repeating == true) {
+                num_pulses_in_burst = num_pulses;
+            }
+            else {
+                num_pulses_in_burst = 0;
+            }
+
+            return true;
+        }
+
+        /**
+         * @brief   Turns the pulser on which just stays on continuously without pulses.
+         * @note    This function should be expanded further in the derived class with more
+         *          hardware-specific code.
+         */
+        virtual inline void turn_on() {
+            is_on = true;
+        }
+
+        /**
+         * @brief   Turns the pulser off.
+         * @note    This function should be expanded further in the derived class with more
+         *          hardware-specific code.
+         */
+        virtual inline void turn_off() {
+            is_on = false;
+        }
+
+        /**
+         * @brief   Handles the current pulsing task if any.
+         * @note    This should ideally not be overridden.
+         */
+        void handle() {
+            // If there are still pulses left to do, and the half-pause has timed out, then toggle
+            // the output.
+            if ((num_pulses_left != 0) && (halfpulse_timer.has_timed_out())) {
+                if (is_on == true) {
+                    // If this is a falling edge, then a full pulse has been done, and decrease the
+                    // number of pulses left.
+                    num_pulses_left--;
+                    turn_off();
+                }
+                else {
+                    turn_on();
+                }
+
+                // If there are still pulses left, then time the next half-pulse.
+                if (num_pulses_left != 0) {
+                    halfpulse_timer.begin(HALFPULSE_PERIOD);
+                }
+                // Else, if it is at least repeating, then time both the dead period and the first
+                // half-pulse and repeat the task.
+                else if (num_pulses_in_burst != 0) {
+                    num_pulses_left = num_pulses_in_burst;
+                    halfpulse_timer.begin(DEAD_PERIOD + HALFPULSE_PERIOD);
+                }
+                // Else, then there is no longer a current pulsing task.
+                else {
+                    current_priority = NONE;
+                }
+            }
+        }
+
+    private:
+        /// @brief  The state of the device, i.e. the output.
+        bool is_on = false;
+        /// @brief  Whether the current pulsing task has repeated bursts.
+        bool is_repeating = false;
+        /// @brief  The priority of the current pulsing task lest an important signal, e.g.
+        ///         the over-temperature alarm, is overridden.
+        /// @note   This is also used as a simple flag to know whether there is a current pulsing
+        ///         task.
+        Priority current_priority = NONE;
+        /// @brief  The number of pulses left to show on the device.
+        /// @note   Behaves as a counter to decrease therefrom.
+        /// @note   A pulse is both a on-period and an off-period.
+        uint8_t num_pulses_left = 0;
+        /// @brief  The total number of pulses in a burst.
+        /// @note   Unlike num_pulses_left, stores a fixed value to refer back to which.
+        /// @note   If this is set to zero, then the pulser does not repeat, and there is only one
+        ///         burst.
+        uint8_t num_pulses_in_burst = 0;
+        /// @brief  The timer to time the half-pulses.
+        /// @note   A half-pulse is either a single on-period or a single off-period.
+        utility::support::MillisecondTimer halfpulse_timer{};
+    };
+
+}  // namespace device
+
+#endif  // DEVICE_PULSER_HPP

--- a/NUSense/Core/Src/device/back_panel/Button.hpp
+++ b/NUSense/Core/Src/device/back_panel/Button.hpp
@@ -79,7 +79,7 @@ namespace device::back_panel {
         /// @brief  The number of lows counted.
         uint16_t n_lows = 0;
         /// @brief  The threshold for debouncing.
-        uint16_t threshold = 0;
+        uint16_t threshold = 10;
     };
 
 }  // namespace device::back_panel

--- a/NUSense/Core/Src/device/back_panel/Button.hpp
+++ b/NUSense/Core/Src/device/back_panel/Button.hpp
@@ -1,9 +1,9 @@
 #include "stm32h753xx.h"
 
-#ifndef DEVICE_BUTTON_HPP
-    #define DEVICE_BUTTON_HPP
+#ifndef DEVICE_BACK_PANEL_BUTTON_HPP
+    #define DEVICE_BACK_PANEL_BUTTON_HPP
 
-namespace device {
+namespace device::back_panel {
 
     /**
      * @brief   The button.
@@ -82,6 +82,6 @@ namespace device {
         uint16_t threshold = 0;
     };
 
-}  // namespace device
+}  // namespace device::back_panel
 
-#endif  // DEVICE_BUTTON_HPP
+#endif  // DEVICE_BACK_PANEL_BUTTON_HPP

--- a/NUSense/Core/Src/device/back_panel/Led.hpp
+++ b/NUSense/Core/Src/device/back_panel/Led.hpp
@@ -1,0 +1,65 @@
+#include "../Pulser.hpp"
+#include "stm32h753xx.h"
+
+#ifndef DEVICE_BACK_PANEL_LED_HPP
+    #define DEVICE_BACK_PANEL_LED_HPP
+
+namespace device::back_panel {
+
+    /**
+     * @brief   The LED which is a pulser.
+     * @note    This is an exercise for the author in bare-metal programming with the SFRs. Let me
+     *          know if there are any better C++ paradigms for SFRs.
+     */
+    class Led : public Pulser {
+    public:
+        /**
+         * @brief    Constructs the LED.
+         * @param    port The reference to the port on which the buzzer is connected.
+         * @param    pin The pin at which the buzzer is connected.
+         */
+        Led(GPIO_TypeDef* port, uint16_t pin) : port(port), pin(pin) {
+            // Set the pin as an output.
+            port->MODER |= (0b01 << (pin * 2));
+            port->MODER &= ~(0b10 << (pin * 2));
+            // Set the output to be open-drain since the LED is electrically pulled high; see the schematic:
+            // https://github.com/ROBOTIS-GIT/ROBOTIS-OP-Series-Data/blob/master/ROBOTIS-OP%2C%20ROBOTIS-OP2/Hardware/Electronics/Boards/DARwIn-OP_Interface_rev3.pdf
+            port->OTYPER |= (0b1 << pin);
+            // Set the pin to high at first.
+            port->BSRR = 1 << pin;
+        }
+
+        /**
+         * @brief   Destructs the LED.
+         * @note    Nothing needs to be freed as of yet.
+         */
+        virtual ~Led() {}
+
+        /**
+         * @brief   Turns the LED on.
+         */
+        inline void turn_on() override {
+            // The pin is reset since the LED is electrically pulled high; see the schematic above.
+            port->BSRR = static_cast<uint32_t>(1 << (pin + 16));
+            Pulser::turn_on();
+        }
+
+        /**
+         * @brief   Turns the LED off.
+         */
+        inline void turn_off() override {
+            // The pin is set since the LED is electrically pulled high; see the schematic above.
+            port->BSRR = 1 << pin;
+            Pulser::turn_off();
+        }
+
+    private:
+        /// @brief  The handler of the peripheral port.
+        GPIO_TypeDef* port = NULL;
+        /// @brief  The pin.
+        uint16_t pin = 0;
+    };
+
+}  // namespace device::back_panel
+
+#endif  // DEVICE_BACK_PANEL_LED_HPP

--- a/NUSense/Core/Src/device/back_panel/Led.hpp
+++ b/NUSense/Core/Src/device/back_panel/Led.hpp
@@ -22,7 +22,8 @@ namespace device::back_panel {
             // Set the pin as an output.
             port->MODER |= (0b01 << (pin * 2));
             port->MODER &= ~(0b10 << (pin * 2));
-            // Set the output to be open-drain since the LED is electrically pulled high; see the schematic:
+            // Set the output to be open-drain since the LED is electrically pulled high; see the
+            // schematic:
             // https://github.com/ROBOTIS-GIT/ROBOTIS-OP-Series-Data/blob/master/ROBOTIS-OP%2C%20ROBOTIS-OP2/Hardware/Electronics/Boards/DARwIn-OP_Interface_rev3.pdf
             port->OTYPER |= (0b1 << pin);
             // Set the pin to high at first.
@@ -39,7 +40,7 @@ namespace device::back_panel {
          * @brief   Turns the LED on.
          */
         inline void turn_on() override {
-            // The pin is reset since the LED is electrically pulled high; see the schematic above.
+            // The pin is reset since the LED is electrically pulled high.
             port->BSRR = static_cast<uint32_t>(1 << (pin + 16));
             Pulser::turn_on();
         }
@@ -48,7 +49,7 @@ namespace device::back_panel {
          * @brief   Turns the LED off.
          */
         inline void turn_off() override {
-            // The pin is set since the LED is electrically pulled high; see the schematic above.
+            // The pin is set since the LED is electrically pulled high.
             port->BSRR = 1 << pin;
             Pulser::turn_off();
         }

--- a/NUSense/Core/Src/device/back_panel/RgbLed.hpp
+++ b/NUSense/Core/Src/device/back_panel/RgbLed.hpp
@@ -1,0 +1,88 @@
+#include "../Pulser.hpp"
+#include "Led.hpp"
+#include "stm32h753xx.h"
+
+#ifndef DEVICE_BACK_PANEL_RGBLED_HPP
+    #define DEVICE_BACK_PANEL_RGBLED_HPP
+
+namespace device::back_panel {
+
+    /**
+     * @brief   The RGB-LED which is a pulser.
+     * @note    This is an exercise for the author in bare-metal programming with the SFRs. Let me
+     *          know if there are any better C++ paradigms for SFRs.
+     * @note    For now, I have settled on basic 3-bit RGB. This will be a placeholder for either
+     *          bitbanged PWM in a loop or a new PCB revision with the RGB LEDs rerouted to PWM
+     *          timers.
+     */
+    class RgbLed : public Pulser {
+    public:
+        /**
+         * @brief    Constructs the RGB-LED.
+         * @param    port The reference to the port on which the buzzer is connected.
+         * @param    pin The pin at which the buzzer is connected.
+         */
+        RgbLed(std::array<Led, 3> leds) : leds(leds) {}
+
+        /**
+         * @brief   Destructs the RGB-LED.
+         * @note    Nothing needs to be freed as of yet.
+         */
+        virtual ~RgbLed() {}
+
+        /**
+         * @brief   Sets the RGB value.
+         * @param   value The RGB value.
+         */
+        void set_value(const uint32_t value) {
+            values[0] = static_cast<uint8_t>(value >> 16);
+            values[1] = static_cast<uint8_t>(value >> 8);
+            values[2] = static_cast<uint8_t>(value >> 0);
+        }
+        void set_value(std::array<uint8_t, 3>& value) {
+            values = value;
+        }
+
+        /**
+         * @brief   Turns the RGB-LED on.
+         */
+        inline void turn_on() override {
+            // For each LED, either turn it on or off depending on its value.
+            for (size_t i = 0; i < 3; i++) {
+                // For now, we will have to live (and suffer) with dumb 3-bit RGB until either the
+                // RGB LEDs are rerouted to PWM timers or someone can be bothered to bitbang PWM in
+                // a loop (which might be a topic for another PR later).
+
+                // Mom, can we have RGB?
+                // No, there is RGB at home.
+                // At home:
+
+                // If the value is greater than 127, then turn it on.
+                values[i] > 127 ? leds[i].turn_on() : leds[i].turn_off();
+            }
+
+            Pulser::turn_on();
+        }
+
+        /**
+         * @brief   Turns the RGB-LED off.
+         */
+        inline void turn_off() override {
+            // Turn each led off.
+            for (auto& led : leds) {
+                led.turn_off();
+            }
+
+            Pulser::turn_off();
+        }
+
+    private:
+        /// @brief  The red, green, and blue values.
+        std::array<uint8_t, 3> values;
+        /// @brief  The red, green, and blue leds.
+        std::array<Led, 3> leds;
+    };
+
+}  // namespace device::back_panel
+
+#endif  // DEVICE_BACK_PANEL_RGBLED_HPP

--- a/NUSense/Core/Src/device/back_panel/RgbLed.hpp
+++ b/NUSense/Core/Src/device/back_panel/RgbLed.hpp
@@ -19,8 +19,7 @@ namespace device::back_panel {
     public:
         /**
          * @brief    Constructs the RGB-LED.
-         * @param    port The reference to the port on which the buzzer is connected.
-         * @param    pin The pin at which the buzzer is connected.
+         * @param    leds an array of the three LEDs, red, green, and blue.
          */
         RgbLed(std::array<Led, 3> leds) : leds(leds) {}
 

--- a/NUSense/Core/Src/nusense/NUSenseIO.hpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO.hpp
@@ -5,8 +5,9 @@
 #include <iterator>
 #include <stdio.h>
 
-#include "../device/Button.hpp"
 #include "../device/Buzzer.hpp"
+#include "../device/back_panel/Button.hpp"
+#include "../device/back_panel/Led.hpp"
 #include "../dynamixel/Chain.hpp"
 #include "../dynamixel/Dynamixel.hpp"
 #include "../dynamixel/PacketHandler.hpp"
@@ -70,10 +71,17 @@ namespace nusense {
         utility::support::MillisecondTimer loop_timer{};
 
         /// @brief  The SW_MODE button
-        device::Button mode_button = device::Button(GPIOC, 15);
+        device::back_panel::Button mode_button = device::back_panel::Button(GPIOC, 15);
 
         /// @brief  The SW_START button
-        device::Button start_button = device::Button(GPIOH, 0);
+        device::back_panel::Button start_button = device::back_panel::Button(GPIOH, 0);
+
+        /// @brief  The LEDs on the back-panel, arranged in the order from left to right.
+        device::back_panel::Led tx_led    = device::back_panel::Led(GPIOC, 14);
+        device::back_panel::Led rx_led    = device::back_panel::Led(GPIOC, 13);
+        device::back_panel::Led red_led   = device::back_panel::Led(GPIOE, 6);
+        device::back_panel::Led blue_led  = device::back_panel::Led(GPIOE, 5);
+        device::back_panel::Led green_led = device::back_panel::Led(GPIOE, 4);
 
         /// @brief  The on-board buzzer
         device::Buzzer buzzer = device::Buzzer(GPIOB, 7);

--- a/NUSense/Core/Src/nusense/NUSenseIO.hpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO.hpp
@@ -8,6 +8,7 @@
 #include "../device/Buzzer.hpp"
 #include "../device/back_panel/Button.hpp"
 #include "../device/back_panel/Led.hpp"
+#include "../device/back_panel/RgbLed.hpp"
 #include "../dynamixel/Chain.hpp"
 #include "../dynamixel/Dynamixel.hpp"
 #include "../dynamixel/PacketHandler.hpp"
@@ -77,11 +78,15 @@ namespace nusense {
         device::back_panel::Button start_button = device::back_panel::Button(GPIOH, 0);
 
         /// @brief  The LEDs on the back-panel, arranged in the order from left to right.
-        device::back_panel::Led tx_led    = device::back_panel::Led(GPIOC, 14);
-        device::back_panel::Led rx_led    = device::back_panel::Led(GPIOC, 13);
-        device::back_panel::Led red_led   = device::back_panel::Led(GPIOE, 6);
-        device::back_panel::Led blue_led  = device::back_panel::Led(GPIOE, 5);
-        device::back_panel::Led green_led = device::back_panel::Led(GPIOE, 4);
+        device::back_panel::Led tx_led      = device::back_panel::Led(GPIOC, 14);
+        device::back_panel::Led rx_led      = device::back_panel::Led(GPIOC, 13);
+        device::back_panel::Led red_led     = device::back_panel::Led(GPIOE, 6);
+        device::back_panel::Led blue_led    = device::back_panel::Led(GPIOE, 5);
+        device::back_panel::Led green_led   = device::back_panel::Led(GPIOE, 4);
+        device::back_panel::RgbLed left_rgb = device::back_panel::RgbLed(
+            {device::back_panel::Led{GPIOE, 3}, device::back_panel::Led{GPIOE, 1}, device::back_panel::Led{GPIOE, 2}});
+        device::back_panel::RgbLed right_rgb = device::back_panel::RgbLed(
+            {device::back_panel::Led{GPIOE, 0}, device::back_panel::Led{GPIOB, 8}, device::back_panel::Led{GPIOB, 9}});
 
         /// @brief  The on-board buzzer
         device::Buzzer buzzer = device::Buzzer(GPIOB, 7);

--- a/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
@@ -185,6 +185,12 @@ namespace nusense {
                 buzzer.pulse(5, true, device::Buzzer::Priority::HIGH);
             }
 
+            // Handle any of the pulser objects.
+            tx_led.handle();
+            rx_led.handle();
+            red_led.handle();
+            blue_led.handle();
+            green_led.handle();
             buzzer.handle();
 
             if (mode_button.filter()) {

--- a/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
@@ -192,6 +192,11 @@ namespace nusense {
 
             if (mode_button.filter()) {
                 buzzer.pulse(1, false, device::Buzzer::Priority::LOW);
+                tx_led.stop();
+            }
+
+            if (start_button.filter()) {
+                tx_led.pulse(3, true, device::Pulser::LOW);
             }
         }
     }

--- a/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
@@ -180,11 +180,6 @@ namespace nusense {
                 }
             }
 
-            // If any servo is hot, then sound the buzzer.
-            if (any_servo_hot) {
-                buzzer.pulse(5, true, device::Buzzer::Priority::HIGH);
-            }
-
             // Handle any of the pulser objects.
             tx_led.handle();
             rx_led.handle();

--- a/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
@@ -191,6 +191,8 @@ namespace nusense {
             red_led.handle();
             blue_led.handle();
             green_led.handle();
+            left_rgb.handle();
+            right_rgb.handle();
             buzzer.handle();
 
             if (mode_button.filter()) {

--- a/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
@@ -196,8 +196,7 @@ namespace nusense {
             buzzer.handle();
 
             if (mode_button.filter()) {
-                SET_SIGNAL_1();
-                RESET_SIGNAL_1();
+                buzzer.pulse(1, false, device::Buzzer::Priority::LOW);
             }
         }
     }

--- a/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/loop.cpp
@@ -182,11 +182,10 @@ namespace nusense {
 
             // If any servo is hot, then sound the buzzer.
             if (any_servo_hot) {
-                buzzer.turn_on();
+                buzzer.pulse(5, true, device::Buzzer::Priority::HIGH);
             }
-            else {
-                buzzer.turn_off();
-            }
+
+            buzzer.handle();
 
             if (mode_button.filter()) {
                 SET_SIGNAL_1();

--- a/NUSense/Core/Src/nusense/NUSenseIO/process_data.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/process_data.cpp
@@ -33,6 +33,10 @@ namespace nusense {
         // Buzz if any servo is hot, use the boolean flag to turn the buzzer off once the servo is no longer hot
         // A servo is defined to be hot if the detected temperature exceeds the maximum tolerance in the configuration
         if (servo_states[servo_index].temperature / servo_states[servo_index].filter_count > 80.0) {
+            // If no servo was hot before, then begin pulsing the buzzer.
+            if (!any_servo_hot) {
+                buzzer.pulse(5, true, device::Buzzer::Priority::HIGH);
+            }
             any_servo_hot = true;
         }
 

--- a/NUSense/Core/Src/nusense/NUSenseIO/startup.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/startup.cpp
@@ -236,6 +236,10 @@ namespace nusense {
         // Begin the 100-Hz timer.
         loop_timer.begin(10);
 
+        // Begin an initial pulse as a heartbeat.
+        right_rgb.set_value(0xFFFF00);
+        right_rgb.pulse(1, true, device::back_panel::Led::Priority::LOW);
+
         // Set the state of each expect status as a response to a write-instruction.
         status_states.fill(StatusState::WRITE_1_RESPONSE);
 

--- a/NUSense/Core/Src/utility/support/MillisecondTimer.hpp
+++ b/NUSense/Core/Src/utility/support/MillisecondTimer.hpp
@@ -1,6 +1,8 @@
 #ifndef UTILITY_SUPPORT_MILLISECONDTIMER_HPP
 #define UTILITY_SUPPORT_MILLISECONDTIMER_HPP
 
+#include "stm32h7xx_hal.h"
+
 namespace utility::support {
 
     /**


### PR DESCRIPTION
This PR adds code to control the output states of the LEDs and the Buzzer.

### Pulser

The biggest contribution is a new class, the `Pulser`, which times and regulates a requested number of pulses. Both the buzzer and the LEDs are instances of the 'Pulser'. Thus, a number of pulses can be requested for either the Buzzer or an LED. These pulses can be useful for displaying minimal messages, much like error codes on a computer. 

The goal of this class is too offload the work regulating pulses from the NUC. In theory, the NUC can request a pulsing task, e.g. five pulses of the red LED, repeated in bursts, and the subcontroller should handle the rest. This is better than the NUC sending multiple messages controlling the LED directly.

The `Pulser` outputs pulses of fixed length, i.e. 1 s. If these are repeated in bursts, then there is a fixed deadperiod of 2 s. Maybe, this can be configurable when a pulsing task is requested.

### Led and RgbLed

Two other classes were made, `Led` and `RgbLed`; the latter is a wrapper for three of the former. Given that not all the RGB LEDs are routed to either peripheral timers or DACs, it is very hard to implement true RGB colour. As a compromise, I have left the RGB LEDs as dumb three-bit RGB colours. That is, each LED is simply either on or off. Therefore, there are only seven colours available.

Later on for future reference, there are two ways to construct true RGB.

- The most proper is to reroute the RGB LEDs to peripheral timers where PWM can be used. But this is hard to do without needing to change many things on the PCB.
- The easiest is to bit-bang and use timed pulses to emulate PWM. However, this may chew up some CPU time.

Either way, this is best implemented as setting the brightness in the `Led` class so that the `RgbLed` class needs only to set the brightness of each of the three `Led` members.