### PR TITLE
Change the IMU's coordinates for the vertical NUC mounting.

### DIFF
--- a/NUSense/Core/Src/nusense/NUSenseIO/send_nusense_data.cpp
+++ b/NUSense/Core/Src/nusense/NUSenseIO/send_nusense_data.cpp
@@ -14,15 +14,15 @@ namespace nusense {
         // We have to do it this way because nanopb will not encode the submessage field if has_msg is set to false
         // Invert the axes since the PCB is upside down.
         nusense_msg.imu.has_accel = true;
-        nusense_msg.imu.accel.x   = converted_data.accelerometer.x;
+        nusense_msg.imu.accel.x   = -converted_data.accelerometer.z;
         nusense_msg.imu.accel.y   = -converted_data.accelerometer.y;
-        nusense_msg.imu.accel.z   = -converted_data.accelerometer.z;
+        nusense_msg.imu.accel.z   = -converted_data.accelerometer.x;
 
         // Invert the axes since the PCB is upside down.
         nusense_msg.imu.has_gyro = true;
-        nusense_msg.imu.gyro.x   = converted_data.gyroscope.x;
+        nusense_msg.imu.gyro.x   = -converted_data.gyroscope.z;
         nusense_msg.imu.gyro.y   = -converted_data.gyroscope.y;
-        nusense_msg.imu.gyro.z   = -converted_data.gyroscope.z;
+        nusense_msg.imu.gyro.z   = -converted_data.gyroscope.x;
 
         nusense_msg.imu.temperature = converted_data.temperature;
         nusense_msg.has_imu         = true;


### PR DESCRIPTION
### Brief

Changes the coordinates of both the accelerometer and the gyroscope since the NUSense board is now mounted vertically.

### Context

We are soon planning to have the NUC vertically mounted inside the torso. Although this mounting is still a prototype, all NUSense robots, namely Sarah and Billie, have been converted over to the vertical mounting. (This is to simplify the number of platform versions currently on the team.) Therefore, because of the changed orientation, the coordinates of the IMU must change.

### Coordinate Transformation

The current rotation from the IMU space to the torso space is
```math
R^{\text{torso}}_{\text{old IMU}} = \begin{bmatrix} 1 & 0 & 0 \\\ 0 & -1 & 0 \\\ 0 & 0 & -1 \end{bmatrix}
```

The vertical mounting is however rotated 90º counterclockwise around the y-axis and then 180º around the z-axis. Therefore, the new rotation is
```math
R^{\text{torso}}_{\text{new IMU}} = \begin{bmatrix} \cos(180) & \sin(180) & 0 \\\ -\sin(180) & \cos(180) & 0 \\\ 0 & 0 & 1 \end{bmatrix} \times  \begin{bmatrix} \cos(-90) & 0 & -\sin(-90) \\\ 0 & 1 & 0 \\\ \sin(-90) & 0 & \cos(-90) \end{bmatrix} = \begin{bmatrix} -1 & 0 & 0 \\\ 0 & -1 & 0 \\\ 0 & 0 & 1 \end{bmatrix} \times  \begin{bmatrix} 0 & 0 & 1 \\\ 0 & 1 & 0 \\\ -1 & 0 & 0 \end{bmatrix} = \begin{bmatrix} 0 & 0 & -1 \\\ 0 & -1 & 0 \\\ -1 & 0 & 0 \end{bmatrix}
```
(Forgive the formatting above; markdown is not working properly for some reason.)

#### Images

A rough sketch of the NUSense board positioned in the torso.

![image](https://github.com/user-attachments/assets/87e02372-ed24-4b36-b2a7-669f5634901f)

Note the coordinate markings on the board. The board is mounted such that the x-axis is pointing down towards the ground.

![image](https://github.com/user-attachments/assets/09aa7d59-9348-4b20-9992-2cec06cfb3ea)