### PR TITLE
Fix compiler error involving unimplemented _getentropy syscall

### DIFF
--- a/NUSense/Core/Src/syscalls.c
+++ b/NUSense/Core/Src/syscalls.c
@@ -153,3 +153,9 @@ int _execve(char *name, char **argv, char **env)
     errno = ENOMEM;
     return -1;
 }
+
+int _getentropy(void* buffer, size_t length)
+{
+    errno = ENOSYS;
+    return -1;
+}


### PR DESCRIPTION
This fixes an error during compilation in which the compiler didn't like that the _getentropy syscall was undefined.
I got this error from a cleanly cloned repo + building in STM32CubeIDE and this commit fixes it 👍
I found the solution here: https://community.st.com/t5/stm32cubeide-mcus/stm32cubeide-to-version-1-15-0-text-getentropy-r-0xe-warning/td-p/654866

Also, it's just a dummy implementation as we don't use the getentropy syscall anywhere in the code, so it doesn't need to be an actual implementation