### PR TITLE
clangd config for ide integration

### DIFF
--- a/NUSense/.clangd
+++ b/NUSense/.clangd
@@ -1,0 +1,2 @@
+Diagnostics:
+  UnusedIncludes: None

--- a/NUSense/.clangd
+++ b/NUSense/.clangd
@@ -1,9 +1,9 @@
 Diagnostics:
   UnusedIncludes: None
   Includes:
-    IgnoreHeader: [
-      Core/Inc/main.h,
-      Drivers/.*]
+    IgnoreHeader:
+      - Core/Inc/main.h,
+      - Drivers/.*
 ---
 If:
   PathMatch: Drivers/.*

--- a/NUSense/.clangd
+++ b/NUSense/.clangd
@@ -1,2 +1,5 @@
+CompileFlags:
+  Compiler: arm-none-eabi-g++
 Diagnostics:
-  UnusedIncludes: None
+  Includes:
+    IgnoreHeader: Core/Inc/main.h

--- a/NUSense/.clangd
+++ b/NUSense/.clangd
@@ -1,5 +1,3 @@
-CompileFlags:
-  Compiler: arm-none-eabi-g++
 Diagnostics:
   Includes:
     IgnoreHeader: [

--- a/NUSense/.clangd
+++ b/NUSense/.clangd
@@ -1,11 +1,2 @@
 Diagnostics:
   UnusedIncludes: None
-  Includes:
-    IgnoreHeader:
-      - Core/Inc/main.h,
-      - Drivers/.*
----
-If:
-  PathMatch: Drivers/.*
-Diagnostics:
-  Suppress: '*'

--- a/NUSense/.clangd
+++ b/NUSense/.clangd
@@ -1,4 +1,5 @@
 Diagnostics:
+  UnusedIncludes: None
   Includes:
     IgnoreHeader: [
       Core/Inc/main.h,

--- a/NUSense/.clangd
+++ b/NUSense/.clangd
@@ -2,4 +2,11 @@ CompileFlags:
   Compiler: arm-none-eabi-g++
 Diagnostics:
   Includes:
-    IgnoreHeader: Core/Inc/main.h
+    IgnoreHeader: [
+      Core/Inc/main.h,
+      Drivers/.*]
+---
+If:
+  PathMatch: Drivers/.*
+Diagnostics:
+  Suppress: '*'

--- a/NUSense/compile_flags.txt
+++ b/NUSense/compile_flags.txt
@@ -1,0 +1,10 @@
+-ICore/Inc
+-IUSB_DEVICE/App
+-IUSB_DEVICE/Target
+-IDrivers/STM32H7xx_HAL_Driver/Inc
+-IDrivers/STM32H7xx_HAL_Driver/Inc/Legacy
+-IMiddlewares/ST/STM32_USB_Device_Library/Core/Inc
+-IMiddlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc
+-IDrivers/CMSIS/Device/ST/STM32H7xx/Include
+-IDrivers/CMSIS/Include
+-ICore/Src

--- a/NUSense/compile_flags.txt
+++ b/NUSense/compile_flags.txt
@@ -1,3 +1,6 @@
+-DDEBUG
+-DSTM32H753xx
+
 -ICore/Inc
 -IUSB_DEVICE/App
 -IUSB_DEVICE/Target


### PR DESCRIPTION
adds files (compile_flags.txt, .clangd) to configure clangd so that the clangd extension can be used in vscode (or anywhere with clangd support) for code highlighting, code completion, etc.
the config also does the following:
1. suppresses warnings about unused includes, since:
- we use includes like module.c -> module.h, where module.h includes the symbols that both the header and source need 
- the stm32 library also uses includes like this, for example we define the modules we want and then include stm32h7xx_hal.h, instead of each individual module (e.g stm32h7xx_hal_spi.h)
2. suppresses errors from the stm32 libraries (under Drivers/)

currently, it uses the default compiler installed on the user's machine, not the target architecture (arm) compiler, for simplicity and so that each user doesn't have to install the cross-compiler