### PR TITLE
Fix Fan Controller Definitions

### DIFF
--- a/NUSense/Core/Inc/fan_controller.h
+++ b/NUSense/Core/Inc/fan_controller.h
@@ -71,6 +71,10 @@ void set_fan_manual_pwm(uint8_t pwm_value);
 /// @return The speed in RPM.
 uint16_t read_fan_speed(uint8_t tachometer);
 
+/// @brief Sets the fan mode between manual and automatic which controls whether the fan speed is driven by the onboard temp or some arbitrary PWM value.
+/// @param mode true for manual mode (Direct Fan Control enabled), false for automatic mode (Direct Fan Control disabled)
+void set_fan_mode(bool mode);
+
 /// @brief Enables or disables the tachometer for the specified fan.
 /// @param tachometer  0 for Tachometer 1, 1 for Tachometer 2
 /// @param enabled true to enable, false to disable

--- a/NUSense/Core/Inc/i2c.h
+++ b/NUSense/Core/Inc/i2c.h
@@ -30,13 +30,6 @@ void MX_I2C3_Init(void);
  */
 void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c);
 
-/**
- * @brief GPIO Initialisation Function
- * @param None
- * @retval None
- */
-void MX_GPIO_Init(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/NUSense/Core/Src/fan_controller.c
+++ b/NUSense/Core/Src/fan_controller.c
@@ -58,6 +58,17 @@ uint16_t read_fan_speed(uint8_t tachometer) {
 	return 60 * 100000 / fan_count / PULSES_PER_REVOLUTION;
 }
 
+void set_fan_mode(bool mode)
+{
+    uint8_t control2 = read_fan_register(REG_CONTROL2);
+    if (mode) {
+        control2 |= (1 << 0); // set bit 0 to enable Direct Fan Control
+    } else {
+        control2 &= ~(1 << 0); // clear bit 0 to disable Direct Fan Control
+    }
+    write_fan_register(REG_CONTROL2, control2);
+}
+
 void fan_controller_init() {
     set_fan_mode(true);
 


### PR DESCRIPTION
TIFU by sending non-compiling code to main. Self-slab.

Against my better judgement, PR #38 sent non-working code to main. In the code that was merged, `set_fan_mode` was never actually defined, and the version that was tested on an actual NUSense was **not** the version that was sent to main, and because there is no build test on this repo, it slipped through and got merged...

This PR fixes this by actually defining `set_fan_mode` and also removes a redundant definition of a function that was brought in by STM32CubeMX.

This code **has been compiled using STM32CubeIDE**, however my existing PR #39 adds a build test to stop this from happening again by the way of PlatformIO integration :D.