### PR TITLE
fix all the compiler warnings

### DIFF
--- a/NUSense/Core/Src/i2c.c
+++ b/NUSense/Core/Src/i2c.c
@@ -52,19 +52,3 @@ void HAL_I2C_MspInit(I2C_HandleTypeDef *hi2c)
     }
 }
 
-static void MX_GPIO_Init(void) {
-    /* USER CODE BEGIN MX_GPIO_Init_1 */
-
-    /* USER CODE END MX_GPIO_Init_1 */
-
-    /* GPIO Ports Clock Enable */
-    __HAL_RCC_GPIOC_CLK_ENABLE();
-    __HAL_RCC_GPIOA_CLK_ENABLE();
-
-    /* I2C GPIO configuration is handled in HAL_I2C_MspInit */
-
-    /* USER CODE BEGIN MX_GPIO_Init_2 */
-
-    /* USER CODE END MX_GPIO_Init_2 */
-}
-

--- a/NUSense/Core/Src/imu.cpp
+++ b/NUSense/Core/Src/imu.cpp
@@ -106,7 +106,7 @@ namespace nusense {
      * @return  none
      */
     void IMU::write_reg(Address addr, uint8_t data) {
-        uint8_t packet[2] = {static_cast<uint8_t>(addr) | IMU_WRITE, data};
+        uint8_t packet[2] = {static_cast<uint8_t>(static_cast<uint8_t>(addr) | IMU_WRITE), data};
 
         HAL_GPIO_WritePin(MPU_NSS_GPIO_Port, MPU_NSS_Pin, GPIO_PIN_RESET);
         HAL_SPI_Transmit(&hspi4, packet, 2, HAL_MAX_DELAY);
@@ -122,7 +122,7 @@ namespace nusense {
      */
     void IMU::read_reg(Address addr, uint8_t* data) {
         uint8_t rx_data[2] = {0xFF, 0xFF};
-        uint8_t packet[2]  = {static_cast<uint8_t>(addr) | IMU_READ, 0x00};
+        uint8_t packet[2]  = {static_cast<uint8_t>(static_cast<uint8_t>(addr) | IMU_READ), 0x00};
 
         HAL_GPIO_WritePin(MPU_NSS_GPIO_Port, MPU_NSS_Pin, GPIO_PIN_RESET);
         HAL_SPI_TransmitReceive(&hspi4, packet, rx_data, 2, HAL_MAX_DELAY);
@@ -147,7 +147,7 @@ namespace nusense {
         for (int i = 0; i < length + 1; i++) {
             rx_data[i] = 0xAA;
             if (i == 0)
-                packet[i] = static_cast<uint8_t>(addr) | IMU_READ;
+                packet[i] = static_cast<uint8_t>(static_cast<uint8_t>(addr) | IMU_READ);
             else
                 packet[i] = 0x00;
         }

--- a/NUSense/Core/Src/uart/Port.cpp
+++ b/NUSense/Core/Src/uart/Port.cpp
@@ -85,8 +85,10 @@ namespace uart {
         // Update the back of the buffer.
         uint16_t old_back = rx_buffer.back;
         rx_buffer.back    = (PORT_BUFFER_SIZE - count) % PORT_BUFFER_SIZE;
-        rx_buffer.size +=
-            rx_buffer.back >= old_back ? rx_buffer.back - old_back : rx_buffer.back + (PORT_BUFFER_SIZE - old_back);
+        rx_buffer.size =
+            rx_buffer.size
+            + (rx_buffer.back >= old_back ? rx_buffer.back - old_back
+                                           : rx_buffer.back + (PORT_BUFFER_SIZE - old_back));
         // Handle if the buffer has overflowed. This should be very unlikely, and if it has happened,
         // then something seriously bad has happened at the protocol-handling level! If this happens,
         // then buffer may be unusable since the DMA may still be updating further down this function

--- a/NUSense/Core/Src/uart/Port.hpp
+++ b/NUSense/Core/Src/uart/Port.hpp
@@ -51,7 +51,7 @@ namespace uart {
                 if (size < PORT_BUFFER_SIZE) {
                     data[back] = byte;
                     back       = (back + 1) % PORT_BUFFER_SIZE;
-                    size++;
+                    size       = size + 1;
                 }
             }
 
@@ -66,7 +66,7 @@ namespace uart {
                 if (size != 0) {
                     byte  = data[front];
                     front = (front + 1) % PORT_BUFFER_SIZE;
-                    size--;
+                    size  = size - 1;
                 }
                 return byte;
             }

--- a/NUSense/Core/Src/usb/PacketHandler.hpp
+++ b/NUSense/Core/Src/usb/PacketHandler.hpp
@@ -66,7 +66,7 @@ namespace usb {
                     // Update index accessor after receiving a packet, making sure to wrap around
                     // in case it exceeds the buffer's length
                     rx_buffer.front = (rx_buffer.front + 1) % RX_BUF_SIZE;
-                    rx_buffer.size--;
+                    rx_buffer.size  = rx_buffer.size - 1;
                 }
                 HAL_NVIC_EnableIRQ(OTG_HS_IRQn);
             }
@@ -189,7 +189,7 @@ namespace usb {
                 }
                 // Move the front forward and decrease the size.
                 rx_buffer.front = (rx_buffer.front + length + offset) % RX_BUF_SIZE;
-                rx_buffer.size -= length + offset;
+                rx_buffer.size  = rx_buffer.size - (length + offset);
             }
             return length;
         }


### PR DESCRIPTION
the compiler warnings irritate me because they mean I have no clue whether the code i'm working on is the thing emitting all the warnings. in theory i'd love to put warnings-as-errors in the CI/CD pipeline but honestly who cares that much. may as well just keep the CI/CD as is.  Thanks.

- Remove duplicate MX_GPIO_Init stub in i2c.c (real one lives in gpio.c)
- Wrap register-address ORs in imu.cpp with explicit uint8_t cast to
  silence narrowing conversion warnings
- Rewrite volatile ring-buffer size updates (++/--/+=/-=) as plain
  assignments in Port.hpp/cpp and PacketHandler.hpp; these compound
  forms are deprecated on volatile in C++20