### PR TITLE
Add CI/CD test for formatting and make errors on warnings for existing build test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,4 @@ jobs:
         run: pip install platformio
 
       - name: Build firmware
-        run: cd NUSense && pio run -e nucleo_h753zi
+        run: cd NUSense && pio run -e nucleo_h753zi_ci

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,9 +1,9 @@
 name: Check code formatting
 
 on:
-  push:
+  pull_request:
     branches:
-      - "**"
+      - main
 jobs:
   clang-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,33 @@
+name: Check code formatting
+
+on:
+  push:
+    branches:
+      - "**"
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install clang-format
+        run: sudo apt-get update && sudo apt-get install -y clang-format-18
+
+      - name: Check formatting
+        working-directory: NUSense
+        run: |
+          FILES=$(find \
+            Core/Src/device \
+            Core/Src/dynamixel \
+            Core/Src/nusense \
+            Core/Src/uart \
+            Core/Src/usb \
+            Core/Src/utility \
+            USB_DEVICE/App \
+            -type f \( -name "*.c" -o -name "*.cpp" -o -name "*.h" -o -name "*.hpp" \) \
+            ! -path "*/protobuf/*")
+          FILES="$FILES Core/Src/main.cpp Core/Src/fan_controller.c Core/Src/imu.cpp Core/Src/test_hw.hpp"
+          clang-format-18 --dry-run --Werror -style=file $FILES

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches:
       - "**"
-
+  pull_request:
+    branches:
+      - "**"
 jobs:
   clang-format:
     runs-on: ubuntu-latest

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,7 +26,6 @@ jobs:
             Core/Src/uart \
             Core/Src/usb \
             Core/Src/utility \
-            USB_DEVICE/App \
             -type f \( -name "*.c" -o -name "*.cpp" -o -name "*.h" -o -name "*.hpp" \) \
             ! -path "*/protobuf/*")
           FILES="$FILES Core/Src/main.cpp Core/Src/fan_controller.c Core/Src/imu.cpp Core/Src/test_hw.hpp"

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - "**"
-  pull_request:
-    branches:
-      - "**"
 jobs:
   clang-format:
     runs-on: ubuntu-latest

--- a/NUSense/Core/Src/device/Pulser.hpp
+++ b/NUSense/Core/Src/device/Pulser.hpp
@@ -132,7 +132,7 @@ namespace device {
                 if (num_pulses_left != 0) {
                     halfpulse_timer.begin(HALFPULSE_PERIOD);
                 }
-                // Else, if it is repeating, then time both the dead period and the first 
+                // Else, if it is repeating, then time both the dead period and the first
                 // half-pulse and repeat the task.
                 else if (num_pulses_in_burst != 0) {
                     num_pulses_left = num_pulses_in_burst;
@@ -151,7 +151,7 @@ namespace device {
          */
         void stop() {
             halfpulse_timer.stop();
-            num_pulses_left = 0;
+            num_pulses_left     = 0;
             num_pulses_in_burst = 0;
             turn_off();
             current_priority = NONE;

--- a/NUSense/Core/Src/fan_controller.c
+++ b/NUSense/Core/Src/fan_controller.c
@@ -1,4 +1,5 @@
 #include "fan_controller.h"
+
 #include <stdbool.h>
 extern I2C_HandleTypeDef hi2c3;
 
@@ -19,29 +20,29 @@ bool fan_warning_state(uint8_t fan_id) {
 
 void set_fan_pwm_freq(uint8_t freq) {
     uint8_t control1 = read_fan_register(REG_CONTROL1);
-    control1 &= ~(0b11 << 3);       // clear bits 3 and 4
-    control1 |= (freq & 0b11) << 3; // set bits 3 and 4 to the desired frequency
+    control1 &= ~(0b11 << 3);        // clear bits 3 and 4
+    control1 |= (freq & 0b11) << 3;  // set bits 3 and 4 to the desired frequency
     write_fan_register(REG_CONTROL1, control1);
 }
 
 void set_fan_spin_up(bool enabled) {
     uint8_t control2 = read_fan_register(REG_CONTROL2);
     if (enabled) {
-        control2 |= (1 << 1); // set bit 1 to enable Spin-Up mode
+        control2 |= (1 << 1);  // set bit 1 to enable Spin-Up mode
     }
     else {
-        control2 &= ~(1 << 1); // clear bit 1 to disable Spin-Up mode
+        control2 &= ~(1 << 1);  // clear bit 1 to disable Spin-Up mode
     }
     write_fan_register(REG_CONTROL2, control2);
 }
 
 void set_fan_tachometer_enabled(uint8_t tachometer, bool enabled) {
     uint8_t control3 = read_fan_register(REG_CONTROL3);
-    if (enabled) {  
-        control3 |= (1 << tachometer);  
-    } 
-    else {  
-        control3 &= ~(1 << tachometer);  
+    if (enabled) {
+        control3 |= (1 << tachometer);
+    }
+    else {
+        control3 &= ~(1 << tachometer);
     }
     write_fan_register(REG_CONTROL3, control3);
 }
@@ -51,20 +52,20 @@ void set_fan_manual_pwm(uint8_t pwm_value) {
 }
 
 uint16_t read_fan_speed(uint8_t tachometer) {
-	uint8_t fan_register = (tachometer == 0 ? REG_FAN1COUNT : REG_FAN2COUNT);
-    uint8_t msb = read_fan_register(fan_register);
-	uint8_t lsb = read_fan_register(fan_register + 1);
-	uint16_t fan_count = (msb << 8) | lsb;
-	return 60 * 100000 / fan_count / PULSES_PER_REVOLUTION;
+    uint8_t fan_register = (tachometer == 0 ? REG_FAN1COUNT : REG_FAN2COUNT);
+    uint8_t msb          = read_fan_register(fan_register);
+    uint8_t lsb          = read_fan_register(fan_register + 1);
+    uint16_t fan_count   = (msb << 8) | lsb;
+    return 60 * 100000 / fan_count / PULSES_PER_REVOLUTION;
 }
 
-void set_fan_mode(bool mode)
-{
+void set_fan_mode(bool mode) {
     uint8_t control2 = read_fan_register(REG_CONTROL2);
     if (mode) {
-        control2 |= (1 << 0); // set bit 0 to enable Direct Fan Control
-    } else {
-        control2 &= ~(1 << 0); // clear bit 0 to disable Direct Fan Control
+        control2 |= (1 << 0);  // set bit 0 to enable Direct Fan Control
+    }
+    else {
+        control2 &= ~(1 << 0);  // clear bit 0 to disable Direct Fan Control
     }
     write_fan_register(REG_CONTROL2, control2);
 }

--- a/NUSense/Core/Src/main.cpp
+++ b/NUSense/Core/Src/main.cpp
@@ -42,8 +42,6 @@ void SystemClock_Config(void);
 int main(void) {
     /* MCU Configuration--------------------------------------------------------*/
 
-    int unused_variable = 10;
-
     /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
     HAL_Init();
 

--- a/NUSense/Core/Src/main.cpp
+++ b/NUSense/Core/Src/main.cpp
@@ -42,6 +42,8 @@ void SystemClock_Config(void);
 int main(void) {
     /* MCU Configuration--------------------------------------------------------*/
 
+    int unused_variable = 10;
+
     /* Reset of all peripherals, Initializes the Flash interface and the Systick. */
     HAL_Init();
 

--- a/NUSense/Core/Src/nusense/Convert.cpp
+++ b/NUSense/Core/Src/nusense/Convert.cpp
@@ -144,7 +144,8 @@ namespace nusense {
             // Range: -210 - +210 = -48.09 rpm - +48.09 rpm
             // Default servo limits for velocity - minimum of all for X-Series, MX-106 and MX-64
             // X-Series has the minimum at 167
-            return utility::math::clamp(int32_t(-167), velocity, int32_t(167)) * 0.229f * 2 * static_cast<float>(M_PI) / 60.0f;
+            return utility::math::clamp(int32_t(-167), velocity, int32_t(167)) * 0.229f * 2 * static_cast<float>(M_PI)
+                   / 60.0f;
         }
 
         int32_t velocity(float velocity) {
@@ -152,7 +153,8 @@ namespace nusense {
             // Range: -210 - +210 = -48.09 rpm - +48.09 rpm
             // Default servo limits for velocity - minimum of all for X-Series, MX-106 and MX-64
             // X-Series has the minimum at 167
-            return int32_t(utility::math::clamp(-167.0f, (velocity * 60.0f / (0.229f * 2 * static_cast<float>(M_PI))), 167.0f));
+            return int32_t(
+                utility::math::clamp(-167.0f, (velocity * 60.0f / (0.229f * 2 * static_cast<float>(M_PI))), 167.0f));
         }
 
         uint32_t profile_velocity(float profile_velocity) {

--- a/NUSense/Core/Src/uart/Port.cpp
+++ b/NUSense/Core/Src/uart/Port.cpp
@@ -87,8 +87,7 @@ namespace uart {
         rx_buffer.back    = (PORT_BUFFER_SIZE - count) % PORT_BUFFER_SIZE;
         rx_buffer.size =
             rx_buffer.size
-            + (rx_buffer.back >= old_back ? rx_buffer.back - old_back
-                                           : rx_buffer.back + (PORT_BUFFER_SIZE - old_back));
+            + (rx_buffer.back >= old_back ? rx_buffer.back - old_back : rx_buffer.back + (PORT_BUFFER_SIZE - old_back));
         // Handle if the buffer has overflowed. This should be very unlikely, and if it has happened,
         // then something seriously bad has happened at the protocol-handling level! If this happens,
         // then buffer may be unusable since the DMA may still be updating further down this function

--- a/NUSense/Core/Src/uart/RS485.h
+++ b/NUSense/Core/Src/uart/RS485.h
@@ -1,14 +1,14 @@
-#include "main.h"       // needed for the GPIO labels and explicit types,
-#include "usart.h"      // needed for UART handles,
-#include "settings.h"   // needed for buzz during test,
 #include "gpio.h"
+#include "main.h"      // needed for the GPIO labels and explicit types,
+#include "settings.h"  // needed for buzz during test,
+#include "usart.h"     // needed for UART handles,
 
 #ifndef UART_RS485_H
-#define UART_RS485_H
+    #define UART_RS485_H
 
 namespace uart {
 
-    //#define DETECT_IDLE_LINE
+    // #define DETECT_IDLE_LINE
 
     #define RS485_RX GPIO_PIN_RESET
     #define RS485_TX GPIO_PIN_SET
@@ -18,10 +18,10 @@ namespace uart {
         /// @brief  the kind of status
         enum status {
             // Keep these values as they are to be compatible with HAL.
-            RS485_OK       = 0x00,
-            RS485_ERROR    = 0x01,
-            RS485_BUSY     = 0x02,
-            RS485_TIMEOUT  = 0x03
+            RS485_OK      = 0x00,
+            RS485_ERROR   = 0x01,
+            RS485_BUSY    = 0x02,
+            RS485_TIMEOUT = 0x03
             // May add some more when the time comes.
         };
         /**
@@ -81,7 +81,7 @@ namespace uart {
 
         /**
          * @brief   Gets the counter for the receiving DMA instance.
-         * @return  the number of bytes yet to be received through the DMA before it is fully 
+         * @return  the number of bytes yet to be received through the DMA before it is fully
          *          complete,
          */
         uint16_t get_receive_counter();
@@ -118,7 +118,7 @@ namespace uart {
 
         /**
          * @brief   Checks for the interrupt-flags for the transmitting to be done.
-         * @note    The DXL direction pin is reset during this function if the flag has been set by 
+         * @note    The DXL direction pin is reset during this function if the flag has been set by
          *          the interrupt.
          * @return  whether the data has been fully transmitted,
          * @retval  #true if the transmitting was done,
@@ -128,15 +128,16 @@ namespace uart {
 
         /**
          * @brief   Gets the counter for the transmitting DMA instance.
-         * @return  the number of bytes yet to be transmitted through the DMA before it is fully 
+         * @return  the number of bytes yet to be transmitted through the DMA before it is fully
          *          complete,
          */
         uint16_t get_transmit_counter();
+
     private:
         /// @brief  the handle of the corresponding UART interface,
         UART_HandleTypeDef* huart;
         /// @brief  the handles of the corresponding DMA interfaces,
-        DMA_HandleTypeDef* hdma_rx, * hdma_tx;
+        DMA_HandleTypeDef *hdma_rx, *hdma_tx;
         /// @brief  the GPIO port of the direction-pin,
         GPIO_TypeDef* gpio_port;
         /// @brief  the GPIO pin of the direction-pin,
@@ -147,6 +148,6 @@ namespace uart {
         uint16_t it_tx_mask;
     };
 
-} // namespace uart
+}  // namespace uart
 
-#endif // UART_RS485_H
+#endif  // UART_RS485_H

--- a/NUSense/platformio.ini
+++ b/NUSense/platformio.ini
@@ -48,3 +48,10 @@ build_flags =
 	-IUSB_DEVICE/Target
 	-IMiddlewares/ST/STM32_USB_Device_Library/Core/Inc
 	-IMiddlewares/ST/STM32_USB_Device_Library/Class/CDC/Inc
+
+; CI build: same as above but stricter
+[env:nucleo_h753zi_ci]
+extends = env:nucleo_h753zi
+build_flags =
+	${env:nucleo_h753zi.build_flags}
+	-Werror


### PR DESCRIPTION
1. Formatting test like on `NUbots/NUbots`
2. Errors on warnings on our existing CI pipeline (I was the biggest culprit of getting crappy warning-ridden code to main)
3. Makes the codebase pass the CI/CD checks by formatting the entire thing to our `.clang-format`


:)